### PR TITLE
Fix MatchResults hooks and time formatting

### DIFF
--- a/src/components/LiveResultsByTournament.tsx
+++ b/src/components/LiveResultsByTournament.tsx
@@ -14,7 +14,7 @@ const getFormattedDateTime = (date: Date) => {
   const month = date.getMonth() + 1;
   const dayOfMonth = date.getDate();
   const hour = date.getHours();
-  const minute = date.getMinutes().toString()
+  const minute = date.getMinutes().toString().padStart(2, '0');
   return `${month}月${dayOfMonth}日(${day}) ${hour}時${minute}分`;
 };
 


### PR DESCRIPTION
## Summary
- avoid violating React Hooks rules in `MatchResults`
- show minutes with leading zero in live results

## Testing
- `npm run lint` *(fails: cannot find `@eslint/eslintrc`)*

------
https://chatgpt.com/codex/tasks/task_e_6841a0b84f64832db015d35f61e88ba8