### PR TITLE
Refactor common tournament table

### DIFF
--- a/src/components/InternationalTournaments.tsx
+++ b/src/components/InternationalTournaments.tsx
@@ -1,61 +1,13 @@
-import styles from '../styles/Results.module.css';
+import ResultsTable from '@/components/ResultsTable';
+import { MatchResult, Stage, Tournament } from '@/types/index';
 
-interface MatchResult {
-  round: string;
-  opponent: string;
-  result: string;
-  score: string;
-}
 
-interface Stage {
-  format: 'round-robin' | 'tournament';
-  group?: string;
-  results: MatchResult[];
-}
-
-interface Tournament {
-  tournament: string;
-  dateRange?: string;
-  location?: string;
-  link?: string;
-  format: 'round-robin' | 'tournament' | 'combined';
-  finalResult?: string;
-  groupStage?: Stage;
-  finalStage?: Stage;
-  results?: MatchResult[];
-}
-
-interface PlayerData {
+interface PlayerMatchesData {
   player: string;
   matches: Tournament[];
 }
 
-function renderTable(results: MatchResult[]) {
-  return (
-    <table className={styles.table}>
-      <thead>
-        <tr>
-          <th>ラウンド</th>
-          <th>対戦相手</th>
-          <th>スコア</th>
-          <th>勝敗</th>
-        </tr>
-      </thead>
-      <tbody>
-        {results.map((match, i) => (
-          <tr key={i}>
-            <td>{match.round}</td>
-            <td>{match.opponent}</td>
-            <td>{match.score}</td>
-            <td>{match.result}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  );
-}
-
-export default function InternationalTournaments({ playerData }: { playerData: PlayerData }) {
+export default function InternationalTournaments({ playerData }: { playerData: PlayerMatchesData }) {
   // playerData.matchesが存在するか確認
   if (!playerData || !playerData.matches) {
     return <div>データがありません。</div>;
@@ -66,41 +18,52 @@ export default function InternationalTournaments({ playerData }: { playerData: P
   );
 
   return (
-    <section className={styles.section}>
-      <h2 className={styles.heading}>🌏 国際大会</h2>
+    <section className="mb-8 px-4">
+      <h2 className="text-xl font-semibold mb-4 text-gray-800 dark:text-gray-100">🌏 国際大会</h2>
       {internationalMatches.length > 0 ? (
         internationalMatches.map((tournament, index) => (
-          <div key={index} className={styles.tournament}>
-            <h3>{tournament.tournament}</h3>
-            {tournament.dateRange && <div className={styles.meta}>日程：{tournament.dateRange}</div>}
-            {tournament.location && <div className={styles.meta}>開催地：{tournament.location}</div>}
-            {tournament.finalResult && <div className={styles.meta}>最終結果：{tournament.finalResult}</div>}
+          <div
+            key={index}
+            className="mb-6 border border-gray-200 dark:border-gray-700 rounded-xl p-4 shadow-sm bg-white dark:bg-gray-800"
+          >
+            <h3 className="text-lg font-bold mb-2">{tournament.tournament}</h3>
+            {tournament.dateRange && (
+              <div className="text-sm text-gray-600 dark:text-gray-300 mb-1">日程：{tournament.dateRange}</div>
+            )}
+            {tournament.location && (
+              <div className="text-sm text-gray-600 dark:text-gray-300 mb-1">開催地：{tournament.location}</div>
+            )}
+            {tournament.finalResult && (
+              <div className="text-sm text-gray-600 dark:text-gray-300 mb-1">最終結果：{tournament.finalResult}</div>
+            )}
             {tournament.link && (
-              <div className={styles.meta}>
-                <a href={tournament.link} target="_blank" rel="noopener noreferrer">大会ページ</a>
+              <div className="text-sm text-gray-600 dark:text-gray-300 mb-1">
+                <a href={tournament.link} target="_blank" rel="noopener noreferrer" className="underline text-blue-600 dark:text-blue-400">
+                  大会ページ
+                </a>
               </div>
             )}
 
             {tournament.format === 'combined' && (
               <>
                 {tournament.groupStage && (
-                  <div className={styles.stage}>
-                    <h4>グループステージ</h4>
-                    {renderTable(tournament.groupStage.results)}
+                  <div className="mb-3">
+                    <h4 className="font-semibold mb-1">グループステージ</h4>
+                    <ResultsTable results={tournament.groupStage.results} />
                   </div>
                 )}
                 {tournament.finalStage && (
-                  <div className={styles.stage}>
-                    <h4>決勝トーナメント</h4>
-                    {renderTable(tournament.finalStage.results)}
+                  <div className="mb-3">
+                    <h4 className="font-semibold mb-1">決勝トーナメント</h4>
+                    <ResultsTable results={tournament.finalStage.results} />
                   </div>
                 )}
               </>
             )}
 
             {tournament.format !== 'combined' && tournament.results && (
-              <div className={styles.stage}>
-                {renderTable(tournament.results)}
+              <div className="mb-3">
+                <ResultsTable results={tournament.results} />
               </div>
             )}
           </div>

--- a/src/components/PlayerResults.tsx
+++ b/src/components/PlayerResults.tsx
@@ -1,5 +1,6 @@
 import PlayerSummaryStats from '@/components/PlayerSummaryStats';
-import { MatchResult, PlayerData, PlayerInfo, PlayerStats, Tournament } from '@/types/index';
+import ResultsTable from '@/components/ResultsTable';
+import { PlayerData, PlayerInfo, PlayerStats, Tournament } from '@/types/index';
 import Link from 'next/link';
 
 type PlayerResultsProps = {
@@ -61,13 +62,13 @@ export default function PlayerResults({ playerData, playerStats, allPlayers }: P
                   {tournament.groupStage && (
                     <div className="mb-3">
                       <h4 className="font-semibold mb-1">グループステージ（{tournament.groupStage.group || 'グループ'}）</h4>
-                      {renderTable(tournament.groupStage.results)}
+                      <ResultsTable results={tournament.groupStage.results} />
                     </div>
                   )}
                   {tournament.finalStage && (
                     <div className="mb-3">
                       <h4 className="font-semibold mb-1">決勝トーナメント</h4>
-                      {renderTable(tournament.finalStage.results)}
+                      <ResultsTable results={tournament.finalStage.results} />
                     </div>
                   )}
                 </>
@@ -76,14 +77,14 @@ export default function PlayerResults({ playerData, playerStats, allPlayers }: P
               {tournament.format === 'tournament' && tournament.results && (
                 <div className="mb-3">
                   <h4 className="font-semibold mb-1">トーナメント</h4>
-                  {renderTable(tournament.results)}
+                  <ResultsTable results={tournament.results} />
                 </div>
               )}
 
               {tournament.format === 'round-robin' && tournament.results && (
                 <div className="mb-3">
                   <h4 className="font-semibold mb-1">ラウンドロビン</h4>
-                  {renderTable(tournament.results)}
+                  <ResultsTable results={tournament.results} />
                 </div>
               )}
             </div>
@@ -94,27 +95,3 @@ export default function PlayerResults({ playerData, playerStats, allPlayers }: P
   );
 }
 
-function renderTable(results: MatchResult[]) {
-  return (
-    <table className="w-full border border-gray-200 dark:border-gray-700 text-sm">
-      <thead className="bg-gray-100 dark:bg-gray-700">
-        <tr>
-          <th className="border-b border-gray-300 dark:border-gray-600 px-2 py-1">ラウンド</th>
-          <th className="border-b border-gray-300 dark:border-gray-600 px-2 py-1">対戦相手</th>
-          <th className="border-b border-gray-300 dark:border-gray-600 px-2 py-1">スコア</th>
-          <th className="border-b border-gray-300 dark:border-gray-600 px-2 py-1">勝敗</th>
-        </tr>
-      </thead>
-      <tbody>
-        {results.map((match, i) => (
-          <tr key={i} className="text-center">
-            <td className="border-b border-gray-200 dark:border-gray-700 px-2 py-1">{match.round}</td>
-            <td className="border-b border-gray-200 dark:border-gray-700 px-2 py-1">{match.opponent}</td>
-            <td className="border-b border-gray-200 dark:border-gray-700 px-2 py-1">{match.score}</td>
-            <td className="border-b border-gray-200 dark:border-gray-700 px-2 py-1">{match.result}</td>
-          </tr>
-        ))}
-      </tbody>
-    </table>
-  );
-}

--- a/src/components/ResultsTable.tsx
+++ b/src/components/ResultsTable.tsx
@@ -1,0 +1,26 @@
+import { MatchResult } from '@/types/index';
+
+export default function ResultsTable({ results, className = '' }: { results: MatchResult[]; className?: string }) {
+  return (
+    <table className={`w-full text-sm border border-gray-200 dark:border-gray-700 ${className}`}>
+      <thead className="bg-gray-100 dark:bg-gray-700">
+        <tr>
+          <th className="border-b border-gray-300 dark:border-gray-600 px-2 py-1">ラウンド</th>
+          <th className="border-b border-gray-300 dark:border-gray-600 px-2 py-1">対戦相手</th>
+          <th className="border-b border-gray-300 dark:border-gray-600 px-2 py-1">スコア</th>
+          <th className="border-b border-gray-300 dark:border-gray-600 px-2 py-1">勝敗</th>
+        </tr>
+      </thead>
+      <tbody>
+        {results.map((match, i) => (
+          <tr key={i} className="text-center">
+            <td className="border-b border-gray-200 dark:border-gray-700 px-2 py-1">{match.round}</td>
+            <td className="border-b border-gray-200 dark:border-gray-700 px-2 py-1">{match.opponent}</td>
+            <td className="border-b border-gray-200 dark:border-gray-700 px-2 py-1">{match.score}</td>
+            <td className="border-b border-gray-200 dark:border-gray-700 px-2 py-1">{match.result}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}


### PR DESCRIPTION
## Summary
- extract a reusable `ResultsTable` component
- replace ad‑hoc table rendering in `PlayerResults` and `InternationalTournaments`
- switch `InternationalTournaments` to Tailwind styles and import shared types

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6841aa591df0832dab490ead7c991700