### PR TITLE
Refactor tournament page logic

### DIFF
--- a/lib/tournamentLogic.ts
+++ b/lib/tournamentLogic.ts
@@ -1,0 +1,146 @@
+// src/lib/tournamentLogic.ts
+import { PlayerInfo, MatchOpponent, TournamentYearData } from '@/types/index';
+import { resultPriority } from '@/lib/utils';
+
+export interface TournamentStats {
+  sortedTeams: {
+    team: string;
+    members: { result: string; resultOrder: number; displayParts: { text: string; id?: string; noLink?: boolean }[] }[];
+    bestRank: number;
+  }[];
+  allNames: string[];
+  totalMatches: number;
+  totalPlayers: number;
+  uniqueTeams: number;
+  totalGamesWon: number;
+  totalGamesLost: number;
+  rankedTeams: { rank: number; team: string; count: number }[];
+}
+
+export function processTournamentData(
+  data: TournamentYearData,
+  allPlayers: PlayerInfo[],
+  unknownPlayers: Record<string, { firstName: string; lastName: string; team: string }>
+): TournamentStats {
+  const teamGroups: Record<string, {
+    team: string;
+    members: { result: string; resultOrder: number; displayParts: { text: string; id?: string; noLink?: boolean }[] }[];
+    bestRank: number;
+  }> = {};
+
+  for (const entry of data.results ?? []) {
+    const players = entry.playerIds.map((id) => {
+      const player = allPlayers.find((p) => p.id === id);
+      if (player) {
+        return { id, name: `${player.lastName}${player.firstName}`, team: player.team ?? '所属不明', noLink: false };
+      } else {
+        const unknown = unknownPlayers[id];
+        return { id, name: unknown ? `${unknown.lastName}${unknown.firstName}` : id, team: unknown?.team ?? '所属不明', noLink: true };
+      }
+    });
+
+    const resultOrder = resultPriority(entry.result);
+
+    if (players.length === 1 || players[0].team === players[1].team) {
+      const team = players[0].team;
+      const displayParts = players.flatMap((p, i) => [
+        { text: p.name, id: p.noLink ? undefined : p.id, noLink: p.noLink },
+        ...(i < players.length - 1 ? [{ text: '・' }] : []),
+      ]);
+
+      if (!teamGroups[team]) {
+        teamGroups[team] = { team, members: [], bestRank: resultOrder };
+      }
+      teamGroups[team].members.push({ result: entry.result, resultOrder, displayParts });
+      teamGroups[team].bestRank = Math.min(teamGroups[team].bestRank, resultOrder);
+    } else {
+      for (const p of players) {
+        const displayParts = [{ text: p.name, id: p.noLink ? undefined : p.id, noLink: p.noLink }];
+        if (!teamGroups[p.team]) {
+          teamGroups[p.team] = { team: p.team, members: [], bestRank: resultOrder };
+        }
+        teamGroups[p.team].members.push({ result: entry.result, resultOrder, displayParts });
+        teamGroups[p.team].bestRank = Math.min(teamGroups[p.team].bestRank, resultOrder);
+      }
+    }
+  }
+
+  const sortedTeams = Object.values(teamGroups).sort((a, b) => {
+    if (a.bestRank !== b.bestRank) return a.bestRank - b.bestRank;
+    return a.team.localeCompare(b.team, 'ja');
+  });
+
+  const matches = data.matches ?? [];
+  const allNames = [...new Set(matches.map((m) => m.name))];
+  const totalMatches = matches.filter((m) => m.result === 'win').length;
+
+  const seenPlayers = new Set<string>();
+  const teamCounter: Record<string, number> = {};
+  let totalGamesWon = 0;
+  let totalGamesLost = 0;
+
+  function findOpponentById(id: string): MatchOpponent | null {
+    for (const match of matches) {
+      for (const op of match.opponents) {
+        if (op.playerId === id || op.tempId === id) return op;
+      }
+    }
+    return null;
+  }
+
+  for (const match of matches) {
+    if (match.result === 'win') {
+      const won = parseInt(match.games.won, 10);
+      const lost = parseInt(match.games.lost, 10);
+      if (!isNaN(won)) totalGamesWon += won;
+      if (!isNaN(lost)) totalGamesLost += lost;
+    }
+    for (const id of match.pair) {
+      if (!seenPlayers.has(id)) {
+        const player = findOpponentById(id);
+        if (player?.team) {
+          teamCounter[player.team] = (teamCounter[player.team] || 0) + 1;
+          seenPlayers.add(id);
+        }
+      }
+    }
+    for (const op of match.opponents) {
+      const id = op.playerId || op.tempId;
+      if (!seenPlayers.has(id)) {
+        teamCounter[op.team] = (teamCounter[op.team] || 0) + 1;
+        seenPlayers.add(id);
+      }
+    }
+  }
+
+  const totalPlayers = seenPlayers.size;
+  const uniqueTeams = Object.keys(teamCounter).length;
+  const sorted = Object.entries(teamCounter).sort((a, b) => b[1] - a[1]);
+  const rankedTeams: { rank: number; team: string; count: number }[] = [];
+  let currentRank = 1;
+  let prevCount: number | null = null;
+  let offset = 0;
+
+  for (let i = 0; i < sorted.length; i++) {
+    const [team, count] = sorted[i];
+    if (count === prevCount) {
+      offset++;
+    } else {
+      currentRank = i + 1 + offset;
+      offset = 0;
+    }
+    rankedTeams.push({ rank: currentRank, team, count });
+    prevCount = count;
+  }
+
+  return {
+    sortedTeams,
+    allNames,
+    totalMatches,
+    totalPlayers,
+    uniqueTeams,
+    totalGamesWon,
+    totalGamesLost,
+    rankedTeams,
+  };
+}

--- a/src/pages/tournaments/[tournamentId]/[year]/index.tsx
+++ b/src/pages/tournaments/[tournamentId]/[year]/index.tsx
@@ -1,7 +1,7 @@
 // src/pages/tournaments/[tournamentId]/[year]/index.tsx
 
 import MetaHead from '@/components/MetaHead';
-import { resultPriority } from '@/lib/utils';
+import { processTournamentData } from '@/lib/tournamentLogic';
 import fs from 'fs';
 import { GetStaticPaths, GetStaticProps } from 'next';
 import Head from 'next/head';
@@ -10,7 +10,7 @@ import path from 'path';
 import { useEffect, useState } from 'react';
 
 import { getAllPlayers } from '@/lib/players';
-import { MatchOpponent, PlayerInfo, TournamentMeta, TournamentYearData } from '@/types/index';
+import { PlayerInfo, TournamentMeta, TournamentYearData } from '@/types/index';
 
 import MatchResults from '@/components/Tournament/MatchResults';
 import Statistics from '@/components/Tournament/Statistics';
@@ -28,57 +28,18 @@ interface TournamentYearResultPageProps {
 export default function TournamentYearResultPage({ year, meta, data, allPlayers, unknownPlayers, hasEntries }: TournamentYearResultPageProps) {
   const pageUrl = `https://softeni-pick.com/tournaments/${meta.id}/${year}`;
 
-  const teamGroups: Record<string, {
-    team: string;
-    members: { result: string; resultOrder: number; displayParts: { text: string; id?: string; noLink?: boolean }[] }[];
-    bestRank: number;
-  }> = {};
-
-  for (const entry of data.results ?? []) {
-    const players = entry.playerIds.map((id) => {
-      const player = allPlayers.find((p) => p.id === id);
-      if (player) {
-        return { id, name: `${player.lastName}${player.firstName}`, team: player.team ?? '所属不明', noLink: false };
-      } else {
-        const unknown = unknownPlayers[id];
-        return { id, name: unknown ? `${unknown.lastName}${unknown.firstName}` : id, team: unknown?.team ?? '所属不明', noLink: true };
-      }
-    });
-
-    const resultOrder = resultPriority(entry.result);
-
-    if (players.length === 1 || players[0].team === players[1].team) {
-      const team = players[0].team;
-      const displayParts = players.flatMap((p, i) => [
-        { text: p.name, id: p.noLink ? undefined : p.id, noLink: p.noLink },
-        ...(i < players.length - 1 ? [{ text: '・' }] : []),
-      ]);
-
-      if (!teamGroups[team]) {
-        teamGroups[team] = { team, members: [], bestRank: resultOrder };
-      }
-      teamGroups[team].members.push({ result: entry.result, resultOrder, displayParts });
-      teamGroups[team].bestRank = Math.min(teamGroups[team].bestRank, resultOrder);
-    } else {
-      for (const p of players) {
-        const displayParts = [{ text: p.name, id: p.noLink ? undefined : p.id, noLink: p.noLink }];
-        if (!teamGroups[p.team]) {
-          teamGroups[p.team] = { team: p.team, members: [], bestRank: resultOrder };
-        }
-        teamGroups[p.team].members.push({ result: entry.result, resultOrder, displayParts });
-        teamGroups[p.team].bestRank = Math.min(teamGroups[p.team].bestRank, resultOrder);
-      }
-    }
-  }
-
-  const sortedTeams = Object.values(teamGroups).sort((a, b) => {
-    if (a.bestRank !== b.bestRank) return a.bestRank - b.bestRank;
-    return a.team.localeCompare(b.team, 'ja');
-  });
+  const {
+    sortedTeams,
+    allNames,
+    totalMatches,
+    totalPlayers,
+    uniqueTeams,
+    totalGamesWon,
+    totalGamesLost,
+    rankedTeams,
+  } = processTournamentData(data, allPlayers, unknownPlayers);
 
   const matches = data.matches ?? [];
-  const allNames = [...new Set(matches.map((m) => m.name))];
-  const totalMatches = matches.filter((m) => m.result === 'win').length;
 
   const [filter, setFilter] = useState<'all' | 'top8' | 'winners'>('all');
   const [searchQuery, setSearchQuery] = useState('');
@@ -90,66 +51,7 @@ export default function TournamentYearResultPage({ year, meta, data, allPlayers,
     } else {
       setSuggestions([]);
     }
-  }, [searchQuery]);
-
-  const seenPlayers = new Set<string>();
-  const teamCounter: Record<string, number> = {};
-  let totalGamesWon = 0;
-  let totalGamesLost = 0;
-
-  function findOpponentById(id: string): MatchOpponent | null {
-    for (const match of matches) {
-      for (const op of match.opponents) {
-        if (op.playerId === id || op.tempId === id) return op;
-      }
-    }
-    return null;
-  }
-
-  for (const match of matches) {
-    if (match.result === 'win') {
-      const won = parseInt(match.games.won, 10);
-      const lost = parseInt(match.games.lost, 10);
-      if (!isNaN(won)) totalGamesWon += won;
-      if (!isNaN(lost)) totalGamesLost += lost;
-    }
-    for (const id of match.pair) {
-      if (!seenPlayers.has(id)) {
-        const player = findOpponentById(id);
-        if (player?.team) {
-          teamCounter[player.team] = (teamCounter[player.team] || 0) + 1;
-          seenPlayers.add(id);
-        }
-      }
-    }
-    for (const op of match.opponents) {
-      const id = op.playerId || op.tempId;
-      if (!seenPlayers.has(id)) {
-        teamCounter[op.team] = (teamCounter[op.team] || 0) + 1;
-        seenPlayers.add(id);
-      }
-    }
-  }
-
-  const totalPlayers = seenPlayers.size;
-  const uniqueTeams = Object.keys(teamCounter).length;
-  const sorted = Object.entries(teamCounter).sort((a, b) => b[1] - a[1]);
-  const rankedTeams: { rank: number; team: string; count: number }[] = [];
-  let currentRank = 1;
-  let prevCount: number | null = null;
-  let offset = 0;
-
-  for (let i = 0; i < sorted.length; i++) {
-    const [team, count] = sorted[i];
-    if (count === prevCount) {
-      offset++;
-    } else {
-      currentRank = i + 1 + offset;
-      offset = 0;
-    }
-    rankedTeams.push({ rank: currentRank, team, count });
-    prevCount = count;
-  }
+  }, [searchQuery, allNames]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- extract tournament processing logic into `lib/tournamentLogic.ts`
- use the new helper in the year result page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/eslintrc')*

------
https://chatgpt.com/codex/tasks/task_e_6842f14cb0bc832d958a5929276927e0