### PR TITLE
feat: 試合詳細と本体ページの相互リンク（siteLink）

### DIFF
--- a/docs/wiki/index.md
+++ b/docs/wiki/index.md
@@ -7,7 +7,7 @@
 - [Project Overview](./project-overview.md)
 - [Architecture](./architecture.md)
 - [Score Feature](./score-feature.md)
-- [Score Site Link (Draft)](./score-site-link.md)
+- [Score Site Link](./score-site-link.md)
 - [Score Analysis](./score-analysis.md)
 - [Public Pages](./public-pages.md)
 - [Tournaments Local](./tournaments-local.md)

--- a/docs/wiki/open-questions.md
+++ b/docs/wiki/open-questions.md
@@ -8,9 +8,14 @@
 
 ## 試合詳細の beta 昇格（検討中 2026-06）
 
-- 試合詳細の公開面を `/beta/matches-results/*` から本体ドメインの indexable な URL（候補: `/matches/*`）へ移設するか
-- 移設する場合の 50 件上限の扱いと、`source_site_tournament_id` を公開 JSON に出す案は、相互リンク設計ドラフト（docs/wiki/score-site-link.md）に統合した（上限撤廃・`siteLink` フィールド方式）
-- 試合詳細 URL の ID を UUID のまま使うか slug 化するか（インデックス開始前が最後の変え時。score-site-link.md 参照）
+設計の詳細とドラフト仕様は docs/wiki/score-site-link.md に集約。主な決定:
+
+- 掲載大会に紐づく試合は大会ページ配下のネスト URL（`/tournaments/.../matches/{UUID}`）で indexable にする
+- 野良試合は当面 `/beta/matches-results/*`（noindex）に残す
+- URL の ID は UUID 維持（slug 化しない）、50 件上限撤廃・追記型生成へ
+- 大会紐付けの誤りは削除→新規作成し直しで対応する
+
+残る Open Question は score-site-link.md 末尾を参照。
 
 ## score データモデル
 

--- a/docs/wiki/score-site-link.md
+++ b/docs/wiki/score-site-link.md
@@ -1,6 +1,31 @@
 # Score Site Link（試合詳細と本体の相互リンク）
 
-ステータス: Draft（2026-06）。未実装の設計仕様。実装後に本文の Draft 表記を外す。
+ステータス: 実装済み（2026-06）。掲載大会に紐づく試合詳細を本体ドメインの indexable な
+ネスト URL で公開し、大会ページ・選手ページと相互リンクする。
+
+## 実装サマリ（2026-06）
+
+- siteLink 解決: `lib/siteLink.mjs`（`resolveMatchSiteLink`）
+- 公開 JSON 生成: `scripts/generate-beta-matches-json.mjs`
+  - 50 件上限を撤廃（全件取得）、出力ディレクトリの全削除をやめ追記型に変更
+  - 各試合に `siteLink`（`{ tournamentPath, entryNos }`）をベイク（野良は null）
+  - Supabase 無し（snapshot 再利用）でも siteLink を再付与するため、`npm run prebuild` で既存試合を移行できる
+- 型: `src/types/database.ts` の `MatchSiteLink` / `Match.siteLink`
+- URL 振り分け: `lib/siteConfig.ts` `getPublicMatchDetailPath(match)`（siteLink 有無で分岐）
+- ネストページ: `src/pages/tournaments/[generation]/[tournamentId]/[year]/[gameCategory]/[ageCategory]/[gender]/matches/[matchId].tsx`
+  - 試合詳細コンポーネントは `/beta/matches-results/[matchId]` と共通
+  - 静的パスは `lib/betaMatchesStatic.ts` `getSiteLinkedMatchPaths()`
+- 逆引き表: `scripts/generate-match-reverse-index.mjs` → `public/data/beta-matches/reverse/{by-tournament,by-player}.json`
+  - 読み出し: `lib/matchReverseIndex.ts`
+  - 表示: 大会ページ・選手結果ページに「スコア詳細のある試合」セクション
+- sitemap: `next-sitemap.config.js` の `additionalPaths` でネスト URL を追加
+  （深いネストの動的 SSG ルートを next-sitemap が自動列挙しないため）
+- 作成 UI のエントリー選択: `src/pages/beta/matches/create.tsx` + dev 専用 API `src/pages/api/tournament-entries.ts`
+- prebuild 連鎖: `generate-beta-matches-json` → `generate-match-reverse-index`
+
+野良試合（siteLink なし）は従来どおり `/beta/matches-results/[matchId]`（noindex）に残す。
+
+設計の意図・決定の経緯は以下を参照。
 
 ## 目的
 
@@ -71,10 +96,40 @@
 - `generateTournamentUrlFromMatch` の二重実装（`lib/tournamentHelpers.ts` / `lib/tournamentClientHelpers.ts`）は `siteLink` 導入で削除する
 - 選手名→playerId の解決規約は lib に共有ヘルパーとして集約する（現状は大会ページ・next-sitemap.config.js などに重複実装）
 
-### 7. URL
+### 7. URL（掲載大会試合と野良試合を分離）
 
-- 試合詳細はフラットな `/matches/{id}` 系を維持する。大会 URL 配下へのネストは不採用（大会に紐づかない試合の置き場がなく、大会 URL 構造の変更に巻き込まれるため）
-- 移設先（本体ドメインで indexable にするか）は別判断（docs/wiki/open-questions.md「試合詳細の beta 昇格」参照）
+掲載大会に紐づく試合と、どの掲載大会にも紐づかない試合（野良試合: 練習試合・未収録大会）を、別空間として扱う。
+
+#### 掲載大会に紐づく試合（indexable 公開面）
+
+- URL は大会ページ配下にネストする
+  - `/tournaments/{generation}/{tournamentId}/{year}/{gameCategory}/{ageCategory}/{gender}/matches/{UUID}`
+  - 例: `/tournaments/all/zennihon-mixed/2026/doubles/none/mixed/matches/2157f9e2-9232-4602-86de-a9a24d123eec`
+- 末尾は素の UUID（試合 ID）。プレフィックスがパス自体で文脈を語るため、slug 化（可読化）は不要
+- このネスト URL は飾りではなく階層そのものなので、間違っていてはいけない。URL プレフィックスは**作成時に大会データから引いた検証済み `siteLink` からのみ生成する**。試合レコードのフリーテキスト由来フィールド（`tournament_gender` 等）からは組まない
+- 生成時に `data/tournaments/details/**` に実在するカテゴリかを検証し、解決できない試合はネスト側に出さず警告を出す
+- `ageCategory` は大会データ（カテゴリファイル名 例: `singles-none-boys.json`）から取得する。試合レコードの `'none'` 決め打ちは使わない
+- canonical / OGP / sitemap / パンくず構造化データはこのネスト URL を正とする
+- 実装ルート（案）: `src/pages/tournaments/[generation]/[tournamentId]/[year]/[gameCategory]/[ageCategory]/[gender]/matches/[matchId].tsx`。既存の試合詳細コンポーネントを再利用し、getStaticPaths を `siteLink` を持つ試合から生成する
+
+#### 野良試合（当面 noindex）
+
+- 当面 `/beta/matches-results/{UUID}`（noindex）に残す
+- score ドメイン戦略が固まった段階で score サイトの `/matches/{UUID}` へ移す方針。本リリースでは急がない
+- 責務分離: 掲載大会分は本体サイトの資産、野良試合は記録ツールの出力
+
+#### 大会紐付けを間違えて作成した場合
+
+- ネスト URL はプレフィックスに大会情報を含むため、紐付けを修正すると URL が変わる
+- リダイレクトでの URL 引き継ぎは行わない。**既存試合を削除し、内容はそのまま新規作成し直す**運用とする
+- エントリー選択式の作成フロー（仕様 3）により誤紐付けの頻度自体を下げる
+
+### 8. URL 解決と振り分け
+
+- `getPublicMatchDetailPath` を `siteLink` の有無で分岐させる
+  - `siteLink` あり → ネスト URL
+  - `siteLink` なし → 野良試合 URL（`/beta/matches-results/{UUID}`）
+- 末尾 UUID がそのままファイルキー（`matches/{UUID}.json`）なので、URL→データの解決は末尾切り出しで済む（slug→UUID の解決表は不要）
 
 ## 既存データの移行
 
@@ -85,12 +140,18 @@
 
 - `src/pages/beta/matches/create.tsx`（エントリー選択 UI）
 - `scripts/generate-beta-matches-json.mjs`（siteLink 付与・追記型化・上限撤廃）
-- `src/pages/beta/matches-results/[matchId]/index.tsx` / `src/pages/matches/**`（siteLink 表示、URL 再構築廃止）
+- `src/pages/tournaments/[generation]/[tournamentId]/[year]/[gameCategory]/[ageCategory]/[gender]/matches/[matchId].tsx`（新規・掲載大会試合の indexable ページ）
+- `src/pages/beta/matches-results/[matchId]/index.tsx` / `src/pages/matches/**`（野良試合表示、URL 振り分け、URL 再構築廃止）
 - 大会ページ・選手ページ（逆引き表の表示）
 - `lib/tournamentHelpers.ts` / `lib/tournamentClientHelpers.ts` / `lib/players.ts`（ヘルパー統一）
 
+## 決定事項
+
+- 試合詳細 URL の ID は UUID を維持し、slug 化はしない（掲載大会試合はネスト URL がパスで文脈を語るため可読化不要）
+- 掲載大会試合と野良試合を別空間に分離する（ネスト URL / `/beta/matches-results`）
+- 大会紐付けの誤りは削除→新規作成し直しで対応し、リダイレクトでの URL 引き継ぎはしない
+
 ## Open Questions
 
-- 試合詳細 URL の ID を UUID のまま使うか、読める slug にするか（インデックス開始前が最後の変え時）
 - 逆引き表の置き場所とファイル分割（全選手 1 ファイルで足りるか）
-- 手入力フォールバック試合に後から `siteLink` を付与する導線を作るか
+- 手入力フォールバック（野良）試合に後から `siteLink` を付与して掲載大会試合へ昇格させる導線を作るか

--- a/lib/betaMatchesStatic.ts
+++ b/lib/betaMatchesStatic.ts
@@ -127,3 +127,53 @@ export const getBetaMatchById = async (matchId: string) => {
   const data = await readJson<BetaMatchDetail>(detailPath);
   return data?.match ?? null;
 };
+
+export interface SiteLinkedMatchPath {
+  generation: string;
+  tournamentId: string;
+  year: string;
+  gameCategory: string;
+  ageCategory: string;
+  gender: string;
+  matchId: string;
+}
+
+// 掲載大会に紐づく試合（siteLink あり）の、ネスト URL 用パスセグメント一覧。
+// tournamentPath は `/tournaments/{generation}/{tournamentId}/{year}/{gameCategory}/{ageCategory}/{gender}`。
+export const getSiteLinkedMatchPaths = async (): Promise<
+  SiteLinkedMatchPath[]
+> => {
+  const matches = await getLatestBetaMatches();
+  const paths: SiteLinkedMatchPath[] = [];
+
+  for (const match of matches) {
+    const tournamentPath = match.siteLink?.tournamentPath;
+    if (!tournamentPath) continue;
+
+    const segments = tournamentPath.split('/').filter(Boolean);
+    // ['tournaments', generation, tournamentId, year, gameCategory, ageCategory, gender]
+    if (segments.length !== 7 || segments[0] !== 'tournaments') continue;
+
+    const [
+      ,
+      generation,
+      tournamentId,
+      year,
+      gameCategory,
+      ageCategory,
+      gender,
+    ] = segments;
+
+    paths.push({
+      generation,
+      tournamentId,
+      year,
+      gameCategory,
+      ageCategory,
+      gender,
+      matchId: match.id,
+    });
+  }
+
+  return paths;
+};

--- a/lib/matchReverseIndex.ts
+++ b/lib/matchReverseIndex.ts
@@ -1,0 +1,51 @@
+import fs from 'fs';
+import path from 'path';
+
+// 本体ページ（大会・選手）→ 試合詳細 の逆引き表を読むサーバー専用ヘルパー。
+// 生成は scripts/generate-match-reverse-index.mjs。
+// getStaticProps からのみ使う（fs 依存のためクライアントへ import しない）。
+// 仕様: docs/wiki/score-site-link.md
+
+export interface ScoreMatchLink {
+  matchId: string;
+  detailPath: string;
+  round: string | null;
+  entryNos: number[];
+  teamA: string;
+  teamB: string;
+}
+
+const reverseRoot = path.join(
+  process.cwd(),
+  'public',
+  'data',
+  'beta-matches',
+  'reverse',
+);
+
+const readJsonIfExists = <T>(filePath: string): T | null => {
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8')) as T;
+  } catch {
+    return null;
+  }
+};
+
+export const getScoreMatchLinksForTournament = (
+  tournamentPath: string,
+): ScoreMatchLink[] => {
+  const data = readJsonIfExists<{
+    tournaments?: Record<string, ScoreMatchLink[]>;
+  }>(path.join(reverseRoot, 'by-tournament.json'));
+  return data?.tournaments?.[tournamentPath] ?? [];
+};
+
+export const getScoreMatchLinksForPlayer = (
+  playerId: string | number,
+): ScoreMatchLink[] => {
+  const data = readJsonIfExists<{
+    players?: Record<string, ScoreMatchLink[]>;
+  }>(path.join(reverseRoot, 'by-player.json'));
+  return data?.players?.[String(playerId)] ?? [];
+};

--- a/lib/siteConfig.ts
+++ b/lib/siteConfig.ts
@@ -67,8 +67,19 @@ export const buildSiteUrl = (path: string) => {
 export const getPublicMatchesListPath = () =>
   isScoreSiteMode() ? '/matches' : '/beta/matches-results';
 
-export const getPublicMatchDetailPath = (matchId: string) =>
-  `${getPublicMatchesListPath()}/${matchId}`;
+// 掲載大会に紐づく試合（siteLink あり）は大会ページ配下のネスト URL、
+// 野良試合（siteLink なし）は従来の一覧配下 URL を返す。
+// score モードでは大会ページ群を持たないため常に一覧配下 URL を使う。
+// 仕様: docs/wiki/score-site-link.md
+export const getPublicMatchDetailPath = (match: {
+  id: string;
+  siteLink?: { tournamentPath: string } | null;
+}) => {
+  if (!isScoreSiteMode() && match.siteLink?.tournamentPath) {
+    return `${match.siteLink.tournamentPath}/matches/${match.id}`;
+  }
+  return `${getPublicMatchesListPath()}/${match.id}`;
+};
 
 export const getPublicMatchesGrowthPath = (targetKey?: string) => {
   const basePath = `${getPublicMatchesListPath()}/growth`;

--- a/lib/siteLink.mjs
+++ b/lib/siteLink.mjs
@@ -1,0 +1,103 @@
+// 試合（score 系）と掲載大会データの対応付けを解決する Node 用ヘルパー。
+//
+// 設計は docs/wiki/score-site-link.md を参照。
+// - 掲載大会に紐づく試合の URL プレフィックスは、検証済みの大会データからのみ生成する
+// - 試合レコードのフリーテキスト由来フィールド（tournament_gender 等）だけでは確定させない
+// - 解決できない試合（野良試合）は null を返し、ネスト URL を出さない
+//
+// ビルド時（generate-beta-matches-json.mjs / 逆引き表生成）にのみ使う。
+// 結果は公開 JSON の match.siteLink にベイクされ、ページ側は fs を触らずに読む。
+
+import fs from 'fs';
+import path from 'path';
+
+const parseEntryNo = (value) => {
+  if (value === null || value === undefined) return null;
+  const numeric = Number(String(value).trim());
+  return Number.isFinite(numeric) ? numeric : null;
+};
+
+const readJsonIfExists = (filePath) => {
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+};
+
+// 大会カテゴリ詳細ファイルに、指定 entryNo がエントリーとして存在するか
+const detailContainsEntryNos = (detail, entryNos) => {
+  const entries = Array.isArray(detail?.entries) ? detail.entries : [];
+  const known = new Set(
+    entries
+      .map((entry) => parseEntryNo(entry?.entryNo))
+      .filter((value) => value !== null),
+  );
+  return entryNos.every((entryNo) => known.has(entryNo));
+};
+
+/**
+ * 試合から siteLink（{ tournamentPath, entryNos }）を解決する。
+ * 紐付けできない場合は null（= 野良試合扱い）。
+ *
+ * @param {object} match 公開スナップショットの試合データ
+ * @param {{ detailsRoot: string }} options data/tournaments/details の絶対パス
+ * @returns {{ tournamentPath: string, entryNos: number[] } | null}
+ */
+export const resolveMatchSiteLink = (match, { detailsRoot }) => {
+  if (!match) return null;
+
+  const generation = match.tournament_generation;
+  const tournamentId = match.tournament_id;
+  const year = match.tournament_year;
+  const gender = match.tournament_gender;
+  const gameCategory = match.tournament_category;
+
+  if (!generation || !tournamentId || !year || !gender || !gameCategory) {
+    return null;
+  }
+
+  const entryA = parseEntryNo(match.team_a_entry_number);
+  const entryB = parseEntryNo(match.team_b_entry_number);
+  if (entryA === null || entryB === null) {
+    return null;
+  }
+  const entryNos = [entryA, entryB];
+
+  const yearDir = path.join(detailsRoot, tournamentId, String(year));
+  if (!fs.existsSync(yearDir)) {
+    return null;
+  }
+
+  // ファイル名は `{gameCategory}-{age}-{gender}.json`。
+  // gameCategory / gender が一致する候補から、entryNo を含むものを選ぶ。
+  let candidateFiles;
+  try {
+    candidateFiles = fs
+      .readdirSync(yearDir)
+      .filter((fileName) => fileName.endsWith('.json'));
+  } catch {
+    return null;
+  }
+
+  const matchingFiles = candidateFiles.filter((fileName) => {
+    const categoryId = fileName.replace(/\.json$/, '');
+    const [category, , fileGender] = categoryId.split('-');
+    return category === gameCategory && fileGender === gender;
+  });
+
+  for (const fileName of matchingFiles) {
+    const detail = readJsonIfExists(path.join(yearDir, fileName));
+    if (!detail) continue;
+    if (!detailContainsEntryNos(detail, entryNos)) continue;
+
+    const categoryId = fileName.replace(/\.json$/, '');
+    const [, age = 'none'] = categoryId.split('-');
+    const tournamentPath = `/tournaments/${generation}/${tournamentId}/${year}/${gameCategory}/${age}/${gender}`;
+
+    return { tournamentPath, entryNos };
+  }
+
+  return null;
+};

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -146,4 +146,42 @@ module.exports = {
       priority: config.priority, // 優先度
     };
   },
+  // 掲載大会に紐づく試合詳細（ネスト URL）を sitemap に追加する。
+  // 深いネストの動的 SSG ルートは next-sitemap が自動列挙しないため、
+  // 公開 JSON（siteLink 付き）から直接補う。
+  // 仕様: docs/wiki/score-site-link.md
+  additionalPaths: async (config) => {
+    const result = [];
+    try {
+      const indexPath = path.join(
+        process.cwd(),
+        'public',
+        'data',
+        'beta-matches',
+        'index.json',
+      );
+      if (!fs.existsSync(indexPath)) return result;
+
+      const index = JSON.parse(fs.readFileSync(indexPath, 'utf-8'));
+      const matches = Array.isArray(index?.matches) ? index.matches : [];
+
+      for (const match of matches) {
+        const tournamentPath = match?.siteLink?.tournamentPath;
+        if (!tournamentPath) continue;
+
+        const loc = `${tournamentPath}/matches/${match.id}`;
+        const lastmod = match.completed_at || match.match_date || undefined;
+
+        result.push({
+          loc,
+          ...(lastmod ? { lastmod } : {}),
+          changefreq: config.changefreq,
+          priority: config.priority,
+        });
+      }
+    } catch (err) {
+      console.error('next-sitemap: failed to add score match paths', err);
+    }
+    return result;
+  },
 };

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "prebuild": "node scripts/generate-players-json.mjs && node scripts/generate-player-analysis.mjs && node scripts/generate-beta-matches-json.mjs",
+    "prebuild": "node scripts/generate-players-json.mjs && node scripts/generate-player-analysis.mjs && node scripts/generate-beta-matches-json.mjs && node scripts/generate-match-reverse-index.mjs",
     "build": "NEXT_PUBLIC_GA_ID=$NEXT_PUBLIC_GA_ID next build",
     "build:adinsight": "node scripts/build-adinsight-site.mjs",
     "check:growth": "node scripts/check-growth-analysis.mjs",

--- a/public/data/beta-matches/index.json
+++ b/public/data/beta-matches/index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-23T00:25:16.972Z",
+  "generatedAt": "2026-06-13T02:10:06.112Z",
   "matches": [
     {
       "id": "2157f9e2-9232-4602-86de-a9a24d123eec",
@@ -132,7 +132,14 @@
           "initial_serve_player_index": 0,
           "created_at": "2026-05-22T15:20:17.213341"
         }
-      ]
+      ],
+      "siteLink": {
+        "tournamentPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys",
+        "entryNos": [
+          156,
+          271
+        ]
+      }
     },
     {
       "id": "31e4715d-c98e-4992-a9ce-e3831c38ec9b",
@@ -265,7 +272,14 @@
           "initial_serve_player_index": 0,
           "created_at": "2026-05-21T23:40:03.17651"
         }
-      ]
+      ],
+      "siteLink": {
+        "tournamentPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys",
+        "entryNos": [
+          239,
+          271
+        ]
+      }
     },
     {
       "id": "37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
@@ -376,7 +390,14 @@
           "initial_serve_player_index": 0,
           "created_at": "2026-05-18T14:54:44.318283"
         }
-      ]
+      ],
+      "siteLink": {
+        "tournamentPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys",
+        "entryNos": [
+          1,
+          36
+        ]
+      }
     },
     {
       "id": "3e2fbc9c-cb76-4e7a-be95-8961103437ae",
@@ -509,7 +530,14 @@
           "initial_serve_player_index": 0,
           "created_at": "2026-05-18T14:32:16.90816"
         }
-      ]
+      ],
+      "siteLink": {
+        "tournamentPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys",
+        "entryNos": [
+          1,
+          127
+        ]
+      }
     },
     {
       "id": "4920c088-0a42-4d49-a224-3c0bf6c28a96",
@@ -642,7 +670,14 @@
           "initial_serve_player_index": 0,
           "created_at": "2026-05-17T14:24:23.852694"
         }
-      ]
+      ],
+      "siteLink": {
+        "tournamentPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys",
+        "entryNos": [
+          1,
+          156
+        ]
+      }
     },
     {
       "id": "5adccffc-9645-4cbb-82e8-58e589cf2f94",
@@ -786,7 +821,14 @@
           "initial_serve_player_index": 0,
           "created_at": "2026-05-17T01:09:48.076997"
         }
-      ]
+      ],
+      "siteLink": {
+        "tournamentPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys",
+        "entryNos": [
+          1,
+          40
+        ]
+      }
     },
     {
       "id": "7ac789f6-096e-47e1-9af8-9031d4175efc",
@@ -930,7 +972,14 @@
           "initial_serve_player_index": 0,
           "created_at": "2026-05-17T00:12:51.16563"
         }
-      ]
+      ],
+      "siteLink": {
+        "tournamentPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys",
+        "entryNos": [
+          14,
+          18
+        ]
+      }
     },
     {
       "id": "4795b5c4-ea33-480a-80ae-96108246806e",
@@ -1063,7 +1112,14 @@
           "initial_serve_player_index": 0,
           "created_at": "2026-05-14T14:57:26.341992"
         }
-      ]
+      ],
+      "siteLink": {
+        "tournamentPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys",
+        "entryNos": [
+          1,
+          145
+        ]
+      }
     },
     {
       "id": "eb0cffa2-1acb-4167-8bfa-6e670f7d1c21",
@@ -1241,7 +1297,14 @@
           "initial_serve_player_index": 0,
           "created_at": "2025-11-09T01:11:54.283924"
         }
-      ]
+      ],
+      "siteLink": {
+        "tournamentPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys",
+        "entryNos": [
+          49,
+          196
+        ]
+      }
     },
     {
       "id": "701fa50b-78d0-4e89-98f5-e82161b0ef19",
@@ -1419,7 +1482,14 @@
           "initial_serve_player_index": 0,
           "created_at": "2025-11-07T10:15:04.463471"
         }
-      ]
+      ],
+      "siteLink": {
+        "tournamentPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys",
+        "entryNos": [
+          92,
+          98
+        ]
+      }
     },
     {
       "id": "5155b158-3db3-41b9-9062-161dceeb0d34",
@@ -1575,7 +1645,14 @@
           "initial_serve_player_index": 0,
           "created_at": "2025-11-06T08:00:45.374594"
         }
-      ]
+      ],
+      "siteLink": {
+        "tournamentPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys",
+        "entryNos": [
+          194,
+          196
+        ]
+      }
     },
     {
       "id": "0a7e33bb-4a12-4e33-aaf9-857eda5697d2",
@@ -1742,7 +1819,8 @@
           "initial_serve_player_index": 0,
           "created_at": "2025-11-06T05:30:11.004442"
         }
-      ]
+      ],
+      "siteLink": null
     },
     {
       "id": "4b74d0c4-0d78-4d7d-a3db-6f70d64881ef",
@@ -1876,7 +1954,14 @@
           "initial_serve_player_index": 0,
           "created_at": "2025-11-06T03:38:11.211085"
         }
-      ]
+      ],
+      "siteLink": {
+        "tournamentPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys",
+        "entryNos": [
+          1,
+          2
+        ]
+      }
     },
     {
       "id": "16de8dd3-e117-4c20-9f51-17db8a848b87",
@@ -2054,7 +2139,14 @@
           "initial_serve_player_index": 0,
           "created_at": "2025-11-05T15:13:37.452811"
         }
-      ]
+      ],
+      "siteLink": {
+        "tournamentPath": "/tournaments/university/zennihon-university/2025/doubles/none/boys",
+        "entryNos": [
+          284,
+          318
+        ]
+      }
     },
     {
       "id": "4c7e9057-cc57-4104-a2bc-e173508a251f",
@@ -2232,7 +2324,14 @@
           "initial_serve_player_index": 0,
           "created_at": "2025-11-04T07:43:20.137232"
         }
-      ]
+      ],
+      "siteLink": {
+        "tournamentPath": "/tournaments/all/zennihon-championship/2024/doubles/none/boys",
+        "entryNos": [
+          95,
+          189
+        ]
+      }
     }
   ]
 }

--- a/public/data/beta-matches/matches/0a7e33bb-4a12-4e33-aaf9-857eda5697d2.json
+++ b/public/data/beta-matches/matches/0a7e33bb-4a12-4e33-aaf9-857eda5697d2.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T04:45:55.725Z",
+  "generatedAt": "2026-06-13T02:10:06.112Z",
   "match": {
     "id": "0a7e33bb-4a12-4e33-aaf9-857eda5697d2",
     "tournament_name": "zennihon-championship-2025",
@@ -1308,6 +1308,7 @@
           }
         ]
       }
-    ]
+    ],
+    "siteLink": null
   }
 }

--- a/public/data/beta-matches/matches/16de8dd3-e117-4c20-9f51-17db8a848b87.json
+++ b/public/data/beta-matches/matches/16de8dd3-e117-4c20-9f51-17db8a848b87.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T04:45:55.725Z",
+  "generatedAt": "2026-06-13T02:10:06.112Z",
   "match": {
     "id": "16de8dd3-e117-4c20-9f51-17db8a848b87",
     "tournament_name": "zennihon-university-2025",
@@ -1574,6 +1574,13 @@
           }
         ]
       }
-    ]
+    ],
+    "siteLink": {
+      "tournamentPath": "/tournaments/university/zennihon-university/2025/doubles/none/boys",
+      "entryNos": [
+        284,
+        318
+      ]
+    }
   }
 }

--- a/public/data/beta-matches/matches/2157f9e2-9232-4602-86de-a9a24d123eec.json
+++ b/public/data/beta-matches/matches/2157f9e2-9232-4602-86de-a9a24d123eec.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-23T00:18:12.207Z",
+  "generatedAt": "2026-06-13T02:10:06.112Z",
   "match": {
     "id": "2157f9e2-9232-4602-86de-a9a24d123eec",
     "tournament_name": "zennihon-singles-2026",
@@ -1086,6 +1086,13 @@
           }
         ]
       }
-    ]
+    ],
+    "siteLink": {
+      "tournamentPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys",
+      "entryNos": [
+        156,
+        271
+      ]
+    }
   }
 }

--- a/public/data/beta-matches/matches/31e4715d-c98e-4992-a9ce-e3831c38ec9b.json
+++ b/public/data/beta-matches/matches/31e4715d-c98e-4992-a9ce-e3831c38ec9b.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-23T00:22:46.038Z",
+  "generatedAt": "2026-06-13T02:10:06.112Z",
   "match": {
     "id": "31e4715d-c98e-4992-a9ce-e3831c38ec9b",
     "tournament_name": "zennihon-singles-2026",
@@ -1017,6 +1017,13 @@
           }
         ]
       }
-    ]
+    ],
+    "siteLink": {
+      "tournamentPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys",
+      "entryNos": [
+        239,
+        271
+      ]
+    }
   }
 }

--- a/public/data/beta-matches/matches/37f9acb5-29c1-4259-b2e1-d443fbcad6ee.json
+++ b/public/data/beta-matches/matches/37f9acb5-29c1-4259-b2e1-d443fbcad6ee.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T04:45:55.725Z",
+  "generatedAt": "2026-06-13T02:10:06.112Z",
   "match": {
     "id": "37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
     "tournament_name": "zennihon-singles-2025",
@@ -738,6 +738,13 @@
           }
         ]
       }
-    ]
+    ],
+    "siteLink": {
+      "tournamentPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys",
+      "entryNos": [
+        1,
+        36
+      ]
+    }
   }
 }

--- a/public/data/beta-matches/matches/3e2fbc9c-cb76-4e7a-be95-8961103437ae.json
+++ b/public/data/beta-matches/matches/3e2fbc9c-cb76-4e7a-be95-8961103437ae.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T04:45:55.725Z",
+  "generatedAt": "2026-06-13T02:10:06.112Z",
   "match": {
     "id": "3e2fbc9c-cb76-4e7a-be95-8961103437ae",
     "tournament_name": "zennihon-singles-2025",
@@ -902,6 +902,13 @@
           }
         ]
       }
-    ]
+    ],
+    "siteLink": {
+      "tournamentPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys",
+      "entryNos": [
+        1,
+        127
+      ]
+    }
   }
 }

--- a/public/data/beta-matches/matches/4795b5c4-ea33-480a-80ae-96108246806e.json
+++ b/public/data/beta-matches/matches/4795b5c4-ea33-480a-80ae-96108246806e.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T04:45:55.725Z",
+  "generatedAt": "2026-06-13T02:10:06.112Z",
   "match": {
     "id": "4795b5c4-ea33-480a-80ae-96108246806e",
     "tournament_name": "zennihon-singles-2025",
@@ -1017,6 +1017,13 @@
           }
         ]
       }
-    ]
+    ],
+    "siteLink": {
+      "tournamentPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys",
+      "entryNos": [
+        1,
+        145
+      ]
+    }
   }
 }

--- a/public/data/beta-matches/matches/4920c088-0a42-4d49-a224-3c0bf6c28a96.json
+++ b/public/data/beta-matches/matches/4920c088-0a42-4d49-a224-3c0bf6c28a96.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T04:45:55.725Z",
+  "generatedAt": "2026-06-13T02:10:06.112Z",
   "match": {
     "id": "4920c088-0a42-4d49-a224-3c0bf6c28a96",
     "tournament_name": "zennihon-singles-2026",
@@ -971,6 +971,13 @@
           }
         ]
       }
-    ]
+    ],
+    "siteLink": {
+      "tournamentPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys",
+      "entryNos": [
+        1,
+        156
+      ]
+    }
   }
 }

--- a/public/data/beta-matches/matches/4b74d0c4-0d78-4d7d-a3db-6f70d64881ef.json
+++ b/public/data/beta-matches/matches/4b74d0c4-0d78-4d7d-a3db-6f70d64881ef.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T04:45:55.725Z",
+  "generatedAt": "2026-06-13T02:10:06.112Z",
   "match": {
     "id": "4b74d0c4-0d78-4d7d-a3db-6f70d64881ef",
     "tournament_name": "zennihon-championship-2025",
@@ -740,6 +740,13 @@
           }
         ]
       }
-    ]
+    ],
+    "siteLink": {
+      "tournamentPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys",
+      "entryNos": [
+        1,
+        2
+      ]
+    }
   }
 }

--- a/public/data/beta-matches/matches/4c7e9057-cc57-4104-a2bc-e173508a251f.json
+++ b/public/data/beta-matches/matches/4c7e9057-cc57-4104-a2bc-e173508a251f.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T04:45:55.725Z",
+  "generatedAt": "2026-06-13T02:10:06.112Z",
   "match": {
     "id": "4c7e9057-cc57-4104-a2bc-e173508a251f",
     "tournament_name": "zennihon-championship-2024",
@@ -1712,6 +1712,13 @@
           }
         ]
       }
-    ]
+    ],
+    "siteLink": {
+      "tournamentPath": "/tournaments/all/zennihon-championship/2024/doubles/none/boys",
+      "entryNos": [
+        95,
+        189
+      ]
+    }
   }
 }

--- a/public/data/beta-matches/matches/5155b158-3db3-41b9-9062-161dceeb0d34.json
+++ b/public/data/beta-matches/matches/5155b158-3db3-41b9-9062-161dceeb0d34.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T04:45:55.725Z",
+  "generatedAt": "2026-06-13T02:10:06.112Z",
   "match": {
     "id": "5155b158-3db3-41b9-9062-161dceeb0d34",
     "tournament_name": "zennihon-championship-2025",
@@ -996,6 +996,13 @@
           }
         ]
       }
-    ]
+    ],
+    "siteLink": {
+      "tournamentPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys",
+      "entryNos": [
+        194,
+        196
+      ]
+    }
   }
 }

--- a/public/data/beta-matches/matches/5adccffc-9645-4cbb-82e8-58e589cf2f94.json
+++ b/public/data/beta-matches/matches/5adccffc-9645-4cbb-82e8-58e589cf2f94.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T04:45:55.725Z",
+  "generatedAt": "2026-06-13T02:10:06.112Z",
   "match": {
     "id": "5adccffc-9645-4cbb-82e8-58e589cf2f94",
     "tournament_name": "zennihon-singles-2026",
@@ -1444,6 +1444,13 @@
           }
         ]
       }
-    ]
+    ],
+    "siteLink": {
+      "tournamentPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys",
+      "entryNos": [
+        1,
+        40
+      ]
+    }
   }
 }

--- a/public/data/beta-matches/matches/701fa50b-78d0-4e89-98f5-e82161b0ef19.json
+++ b/public/data/beta-matches/matches/701fa50b-78d0-4e89-98f5-e82161b0ef19.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T04:45:55.725Z",
+  "generatedAt": "2026-06-13T02:10:06.112Z",
   "match": {
     "id": "701fa50b-78d0-4e89-98f5-e82161b0ef19",
     "tournament_name": "zennihon-championship-2025",
@@ -1827,6 +1827,13 @@
           }
         ]
       }
-    ]
+    ],
+    "siteLink": {
+      "tournamentPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys",
+      "entryNos": [
+        92,
+        98
+      ]
+    }
   }
 }

--- a/public/data/beta-matches/matches/7ac789f6-096e-47e1-9af8-9031d4175efc.json
+++ b/public/data/beta-matches/matches/7ac789f6-096e-47e1-9af8-9031d4175efc.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T04:45:55.725Z",
+  "generatedAt": "2026-06-13T02:10:06.112Z",
   "match": {
     "id": "7ac789f6-096e-47e1-9af8-9031d4175efc",
     "tournament_name": "zennihon-singles-2026",
@@ -1352,6 +1352,13 @@
           }
         ]
       }
-    ]
+    ],
+    "siteLink": {
+      "tournamentPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys",
+      "entryNos": [
+        14,
+        18
+      ]
+    }
   }
 }

--- a/public/data/beta-matches/matches/eb0cffa2-1acb-4167-8bfa-6e670f7d1c21.json
+++ b/public/data/beta-matches/matches/eb0cffa2-1acb-4167-8bfa-6e670f7d1c21.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-05-22T04:45:55.725Z",
+  "generatedAt": "2026-06-13T02:10:06.112Z",
   "match": {
     "id": "eb0cffa2-1acb-4167-8bfa-6e670f7d1c21",
     "tournament_name": "zennihon-championship-2025",
@@ -1643,6 +1643,13 @@
           }
         ]
       }
-    ]
+    ],
+    "siteLink": {
+      "tournamentPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys",
+      "entryNos": [
+        49,
+        196
+      ]
+    }
   }
 }

--- a/public/data/beta-matches/reverse/by-player.json
+++ b/public/data/beta-matches/reverse/by-player.json
@@ -1,0 +1,489 @@
+{
+  "generatedAt": "2026-06-13T02:40:58.069Z",
+  "players": {
+    "3": [
+      {
+        "matchId": "4c7e9057-cc57-4104-a2bc-e173508a251f",
+        "detailPath": "/tournaments/all/zennihon-championship/2024/doubles/none/boys/matches/4c7e9057-cc57-4104-a2bc-e173508a251f",
+        "round": "決勝",
+        "entryNos": [
+          95,
+          189
+        ],
+        "teamA": "内本・内田",
+        "teamB": "船水・上松"
+      }
+    ],
+    "4": [
+      {
+        "matchId": "4795b5c4-ea33-480a-80ae-96108246806e",
+        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/4795b5c4-ea33-480a-80ae-96108246806e",
+        "round": "決勝",
+        "entryNos": [
+          1,
+          145
+        ],
+        "teamA": "上松",
+        "teamB": "橋場"
+      },
+      {
+        "matchId": "eb0cffa2-1acb-4167-8bfa-6e670f7d1c21",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/eb0cffa2-1acb-4167-8bfa-6e670f7d1c21",
+        "round": "決勝",
+        "entryNos": [
+          49,
+          196
+        ],
+        "teamA": "橋場・菊山",
+        "teamB": "上岡・丸山"
+      }
+    ],
+    "5": [
+      {
+        "matchId": "701fa50b-78d0-4e89-98f5-e82161b0ef19",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/701fa50b-78d0-4e89-98f5-e82161b0ef19",
+        "round": "3回戦",
+        "entryNos": [
+          92,
+          98
+        ],
+        "teamA": "橋本・増田",
+        "teamB": "片岡・黒坂"
+      }
+    ],
+    "8": [
+      {
+        "matchId": "701fa50b-78d0-4e89-98f5-e82161b0ef19",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/701fa50b-78d0-4e89-98f5-e82161b0ef19",
+        "round": "3回戦",
+        "entryNos": [
+          92,
+          98
+        ],
+        "teamA": "橋本・増田",
+        "teamB": "片岡・黒坂"
+      },
+      {
+        "matchId": "16de8dd3-e117-4c20-9f51-17db8a848b87",
+        "detailPath": "/tournaments/university/zennihon-university/2025/doubles/none/boys/matches/16de8dd3-e117-4c20-9f51-17db8a848b87",
+        "round": "6回戦",
+        "entryNos": [
+          284,
+          318
+        ],
+        "teamA": "片岡・黒坂",
+        "teamB": "清水・宮田"
+      }
+    ],
+    "10": [
+      {
+        "matchId": "37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
+        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
+        "round": "6回戦",
+        "entryNos": [
+          1,
+          36
+        ],
+        "teamA": "上松",
+        "teamB": "黒坂"
+      },
+      {
+        "matchId": "5adccffc-9645-4cbb-82e8-58e589cf2f94",
+        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/5adccffc-9645-4cbb-82e8-58e589cf2f94",
+        "round": "準々決勝",
+        "entryNos": [
+          1,
+          40
+        ],
+        "teamA": "上松",
+        "teamB": "黒坂"
+      },
+      {
+        "matchId": "701fa50b-78d0-4e89-98f5-e82161b0ef19",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/701fa50b-78d0-4e89-98f5-e82161b0ef19",
+        "round": "3回戦",
+        "entryNos": [
+          92,
+          98
+        ],
+        "teamA": "橋本・増田",
+        "teamB": "片岡・黒坂"
+      },
+      {
+        "matchId": "16de8dd3-e117-4c20-9f51-17db8a848b87",
+        "detailPath": "/tournaments/university/zennihon-university/2025/doubles/none/boys/matches/16de8dd3-e117-4c20-9f51-17db8a848b87",
+        "round": "6回戦",
+        "entryNos": [
+          284,
+          318
+        ],
+        "teamA": "片岡・黒坂",
+        "teamB": "清水・宮田"
+      }
+    ],
+    "12": [
+      {
+        "matchId": "eb0cffa2-1acb-4167-8bfa-6e670f7d1c21",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/eb0cffa2-1acb-4167-8bfa-6e670f7d1c21",
+        "round": "決勝",
+        "entryNos": [
+          49,
+          196
+        ],
+        "teamA": "橋場・菊山",
+        "teamB": "上岡・丸山"
+      },
+      {
+        "matchId": "5155b158-3db3-41b9-9062-161dceeb0d34",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/5155b158-3db3-41b9-9062-161dceeb0d34",
+        "round": "2回戦",
+        "entryNos": [
+          194,
+          196
+        ],
+        "teamA": "酒井・前道",
+        "teamB": "上岡・丸山"
+      }
+    ],
+    "15": [
+      {
+        "matchId": "16de8dd3-e117-4c20-9f51-17db8a848b87",
+        "detailPath": "/tournaments/university/zennihon-university/2025/doubles/none/boys/matches/16de8dd3-e117-4c20-9f51-17db8a848b87",
+        "round": "6回戦",
+        "entryNos": [
+          284,
+          318
+        ],
+        "teamA": "片岡・黒坂",
+        "teamB": "清水・宮田"
+      }
+    ],
+    "16": [
+      {
+        "matchId": "4c7e9057-cc57-4104-a2bc-e173508a251f",
+        "detailPath": "/tournaments/all/zennihon-championship/2024/doubles/none/boys/matches/4c7e9057-cc57-4104-a2bc-e173508a251f",
+        "round": "決勝",
+        "entryNos": [
+          95,
+          189
+        ],
+        "teamA": "内本・内田",
+        "teamB": "船水・上松"
+      }
+    ],
+    "17": [
+      {
+        "matchId": "4b74d0c4-0d78-4d7d-a3db-6f70d64881ef",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/4b74d0c4-0d78-4d7d-a3db-6f70d64881ef",
+        "round": "2回戦",
+        "entryNos": [
+          1,
+          2
+        ],
+        "teamA": "内本・上松",
+        "teamB": "辻浦・福島"
+      },
+      {
+        "matchId": "4c7e9057-cc57-4104-a2bc-e173508a251f",
+        "detailPath": "/tournaments/all/zennihon-championship/2024/doubles/none/boys/matches/4c7e9057-cc57-4104-a2bc-e173508a251f",
+        "round": "決勝",
+        "entryNos": [
+          95,
+          189
+        ],
+        "teamA": "内本・内田",
+        "teamB": "船水・上松"
+      }
+    ],
+    "18": [
+      {
+        "matchId": "2157f9e2-9232-4602-86de-a9a24d123eec",
+        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/2157f9e2-9232-4602-86de-a9a24d123eec",
+        "round": "準決勝",
+        "entryNos": [
+          156,
+          271
+        ],
+        "teamA": "植田",
+        "teamB": "上岡"
+      },
+      {
+        "matchId": "3e2fbc9c-cb76-4e7a-be95-8961103437ae",
+        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/3e2fbc9c-cb76-4e7a-be95-8961103437ae",
+        "round": "準決勝",
+        "entryNos": [
+          1,
+          127
+        ],
+        "teamA": "上松",
+        "teamB": "植田"
+      },
+      {
+        "matchId": "4920c088-0a42-4d49-a224-3c0bf6c28a96",
+        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/4920c088-0a42-4d49-a224-3c0bf6c28a96",
+        "round": "決勝",
+        "entryNos": [
+          1,
+          156
+        ],
+        "teamA": "上松",
+        "teamB": "植田"
+      }
+    ],
+    "19": [
+      {
+        "matchId": "37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
+        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
+        "round": "6回戦",
+        "entryNos": [
+          1,
+          36
+        ],
+        "teamA": "上松",
+        "teamB": "黒坂"
+      },
+      {
+        "matchId": "3e2fbc9c-cb76-4e7a-be95-8961103437ae",
+        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/3e2fbc9c-cb76-4e7a-be95-8961103437ae",
+        "round": "準決勝",
+        "entryNos": [
+          1,
+          127
+        ],
+        "teamA": "上松",
+        "teamB": "植田"
+      },
+      {
+        "matchId": "4920c088-0a42-4d49-a224-3c0bf6c28a96",
+        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/4920c088-0a42-4d49-a224-3c0bf6c28a96",
+        "round": "決勝",
+        "entryNos": [
+          1,
+          156
+        ],
+        "teamA": "上松",
+        "teamB": "植田"
+      },
+      {
+        "matchId": "5adccffc-9645-4cbb-82e8-58e589cf2f94",
+        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/5adccffc-9645-4cbb-82e8-58e589cf2f94",
+        "round": "準々決勝",
+        "entryNos": [
+          1,
+          40
+        ],
+        "teamA": "上松",
+        "teamB": "黒坂"
+      },
+      {
+        "matchId": "4795b5c4-ea33-480a-80ae-96108246806e",
+        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/4795b5c4-ea33-480a-80ae-96108246806e",
+        "round": "決勝",
+        "entryNos": [
+          1,
+          145
+        ],
+        "teamA": "上松",
+        "teamB": "橋場"
+      },
+      {
+        "matchId": "4b74d0c4-0d78-4d7d-a3db-6f70d64881ef",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/4b74d0c4-0d78-4d7d-a3db-6f70d64881ef",
+        "round": "2回戦",
+        "entryNos": [
+          1,
+          2
+        ],
+        "teamA": "内本・上松",
+        "teamB": "辻浦・福島"
+      },
+      {
+        "matchId": "4c7e9057-cc57-4104-a2bc-e173508a251f",
+        "detailPath": "/tournaments/all/zennihon-championship/2024/doubles/none/boys/matches/4c7e9057-cc57-4104-a2bc-e173508a251f",
+        "round": "決勝",
+        "entryNos": [
+          95,
+          189
+        ],
+        "teamA": "内本・内田",
+        "teamB": "船水・上松"
+      }
+    ],
+    "20": [
+      {
+        "matchId": "2157f9e2-9232-4602-86de-a9a24d123eec",
+        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/2157f9e2-9232-4602-86de-a9a24d123eec",
+        "round": "準決勝",
+        "entryNos": [
+          156,
+          271
+        ],
+        "teamA": "植田",
+        "teamB": "上岡"
+      },
+      {
+        "matchId": "31e4715d-c98e-4992-a9ce-e3831c38ec9b",
+        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/31e4715d-c98e-4992-a9ce-e3831c38ec9b",
+        "round": "準々決勝",
+        "entryNos": [
+          239,
+          271
+        ],
+        "teamA": "塚本",
+        "teamB": "上岡"
+      },
+      {
+        "matchId": "eb0cffa2-1acb-4167-8bfa-6e670f7d1c21",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/eb0cffa2-1acb-4167-8bfa-6e670f7d1c21",
+        "round": "決勝",
+        "entryNos": [
+          49,
+          196
+        ],
+        "teamA": "橋場・菊山",
+        "teamB": "上岡・丸山"
+      },
+      {
+        "matchId": "5155b158-3db3-41b9-9062-161dceeb0d34",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/5155b158-3db3-41b9-9062-161dceeb0d34",
+        "round": "2回戦",
+        "entryNos": [
+          194,
+          196
+        ],
+        "teamA": "酒井・前道",
+        "teamB": "上岡・丸山"
+      }
+    ],
+    "35": [
+      {
+        "matchId": "eb0cffa2-1acb-4167-8bfa-6e670f7d1c21",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/eb0cffa2-1acb-4167-8bfa-6e670f7d1c21",
+        "round": "決勝",
+        "entryNos": [
+          49,
+          196
+        ],
+        "teamA": "橋場・菊山",
+        "teamB": "上岡・丸山"
+      }
+    ],
+    "45": [
+      {
+        "matchId": "16de8dd3-e117-4c20-9f51-17db8a848b87",
+        "detailPath": "/tournaments/university/zennihon-university/2025/doubles/none/boys/matches/16de8dd3-e117-4c20-9f51-17db8a848b87",
+        "round": "6回戦",
+        "entryNos": [
+          284,
+          318
+        ],
+        "teamA": "片岡・黒坂",
+        "teamB": "清水・宮田"
+      }
+    ],
+    "130": [
+      {
+        "matchId": "701fa50b-78d0-4e89-98f5-e82161b0ef19",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/701fa50b-78d0-4e89-98f5-e82161b0ef19",
+        "round": "3回戦",
+        "entryNos": [
+          92,
+          98
+        ],
+        "teamA": "橋本・増田",
+        "teamB": "片岡・黒坂"
+      }
+    ],
+    "159": [
+      {
+        "matchId": "31e4715d-c98e-4992-a9ce-e3831c38ec9b",
+        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/31e4715d-c98e-4992-a9ce-e3831c38ec9b",
+        "round": "準々決勝",
+        "entryNos": [
+          239,
+          271
+        ],
+        "teamA": "塚本",
+        "teamB": "上岡"
+      }
+    ],
+    "179": [
+      {
+        "matchId": "7ac789f6-096e-47e1-9af8-9031d4175efc",
+        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/7ac789f6-096e-47e1-9af8-9031d4175efc",
+        "round": "4回戦",
+        "entryNos": [
+          14,
+          18
+        ],
+        "teamA": "広光",
+        "teamB": "白川"
+      }
+    ],
+    "346": [
+      {
+        "matchId": "4b74d0c4-0d78-4d7d-a3db-6f70d64881ef",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/4b74d0c4-0d78-4d7d-a3db-6f70d64881ef",
+        "round": "2回戦",
+        "entryNos": [
+          1,
+          2
+        ],
+        "teamA": "内本・上松",
+        "teamB": "辻浦・福島"
+      }
+    ],
+    "392": [
+      {
+        "matchId": "7ac789f6-096e-47e1-9af8-9031d4175efc",
+        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/7ac789f6-096e-47e1-9af8-9031d4175efc",
+        "round": "4回戦",
+        "entryNos": [
+          14,
+          18
+        ],
+        "teamA": "広光",
+        "teamB": "白川"
+      }
+    ],
+    "620": [
+      {
+        "matchId": "4b74d0c4-0d78-4d7d-a3db-6f70d64881ef",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/4b74d0c4-0d78-4d7d-a3db-6f70d64881ef",
+        "round": "2回戦",
+        "entryNos": [
+          1,
+          2
+        ],
+        "teamA": "内本・上松",
+        "teamB": "辻浦・福島"
+      }
+    ],
+    "835": [
+      {
+        "matchId": "5155b158-3db3-41b9-9062-161dceeb0d34",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/5155b158-3db3-41b9-9062-161dceeb0d34",
+        "round": "2回戦",
+        "entryNos": [
+          194,
+          196
+        ],
+        "teamA": "酒井・前道",
+        "teamB": "上岡・丸山"
+      }
+    ],
+    "1148": [
+      {
+        "matchId": "5155b158-3db3-41b9-9062-161dceeb0d34",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/5155b158-3db3-41b9-9062-161dceeb0d34",
+        "round": "2回戦",
+        "entryNos": [
+          194,
+          196
+        ],
+        "teamA": "酒井・前道",
+        "teamB": "上岡・丸山"
+      }
+    ]
+  }
+}

--- a/public/data/beta-matches/reverse/by-player.json
+++ b/public/data/beta-matches/reverse/by-player.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-06-13T02:40:58.069Z",
+  "generatedAt": "2026-06-13T04:45:06.650Z",
   "players": {
     "3": [
       {
@@ -53,17 +53,6 @@
     ],
     "8": [
       {
-        "matchId": "701fa50b-78d0-4e89-98f5-e82161b0ef19",
-        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/701fa50b-78d0-4e89-98f5-e82161b0ef19",
-        "round": "3回戦",
-        "entryNos": [
-          92,
-          98
-        ],
-        "teamA": "橋本・増田",
-        "teamB": "片岡・黒坂"
-      },
-      {
         "matchId": "16de8dd3-e117-4c20-9f51-17db8a848b87",
         "detailPath": "/tournaments/university/zennihon-university/2025/doubles/none/boys/matches/16de8dd3-e117-4c20-9f51-17db8a848b87",
         "round": "6回戦",
@@ -73,20 +62,20 @@
         ],
         "teamA": "片岡・黒坂",
         "teamB": "清水・宮田"
+      },
+      {
+        "matchId": "701fa50b-78d0-4e89-98f5-e82161b0ef19",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/701fa50b-78d0-4e89-98f5-e82161b0ef19",
+        "round": "3回戦",
+        "entryNos": [
+          92,
+          98
+        ],
+        "teamA": "橋本・増田",
+        "teamB": "片岡・黒坂"
       }
     ],
     "10": [
-      {
-        "matchId": "37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
-        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
-        "round": "6回戦",
-        "entryNos": [
-          1,
-          36
-        ],
-        "teamA": "上松",
-        "teamB": "黒坂"
-      },
       {
         "matchId": "5adccffc-9645-4cbb-82e8-58e589cf2f94",
         "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/5adccffc-9645-4cbb-82e8-58e589cf2f94",
@@ -99,15 +88,15 @@
         "teamB": "黒坂"
       },
       {
-        "matchId": "701fa50b-78d0-4e89-98f5-e82161b0ef19",
-        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/701fa50b-78d0-4e89-98f5-e82161b0ef19",
-        "round": "3回戦",
+        "matchId": "37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
+        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
+        "round": "6回戦",
         "entryNos": [
-          92,
-          98
+          1,
+          36
         ],
-        "teamA": "橋本・増田",
-        "teamB": "片岡・黒坂"
+        "teamA": "上松",
+        "teamB": "黒坂"
       },
       {
         "matchId": "16de8dd3-e117-4c20-9f51-17db8a848b87",
@@ -119,6 +108,17 @@
         ],
         "teamA": "片岡・黒坂",
         "teamB": "清水・宮田"
+      },
+      {
+        "matchId": "701fa50b-78d0-4e89-98f5-e82161b0ef19",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/701fa50b-78d0-4e89-98f5-e82161b0ef19",
+        "round": "3回戦",
+        "entryNos": [
+          92,
+          98
+        ],
+        "teamA": "橋本・増田",
+        "teamB": "片岡・黒坂"
       }
     ],
     "12": [
@@ -173,17 +173,6 @@
     ],
     "17": [
       {
-        "matchId": "4b74d0c4-0d78-4d7d-a3db-6f70d64881ef",
-        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/4b74d0c4-0d78-4d7d-a3db-6f70d64881ef",
-        "round": "2回戦",
-        "entryNos": [
-          1,
-          2
-        ],
-        "teamA": "内本・上松",
-        "teamB": "辻浦・福島"
-      },
-      {
         "matchId": "4c7e9057-cc57-4104-a2bc-e173508a251f",
         "detailPath": "/tournaments/all/zennihon-championship/2024/doubles/none/boys/matches/4c7e9057-cc57-4104-a2bc-e173508a251f",
         "round": "決勝",
@@ -193,9 +182,31 @@
         ],
         "teamA": "内本・内田",
         "teamB": "船水・上松"
+      },
+      {
+        "matchId": "4b74d0c4-0d78-4d7d-a3db-6f70d64881ef",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/4b74d0c4-0d78-4d7d-a3db-6f70d64881ef",
+        "round": "2回戦",
+        "entryNos": [
+          1,
+          2
+        ],
+        "teamA": "内本・上松",
+        "teamB": "辻浦・福島"
       }
     ],
     "18": [
+      {
+        "matchId": "4920c088-0a42-4d49-a224-3c0bf6c28a96",
+        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/4920c088-0a42-4d49-a224-3c0bf6c28a96",
+        "round": "決勝",
+        "entryNos": [
+          1,
+          156
+        ],
+        "teamA": "上松",
+        "teamB": "植田"
+      },
       {
         "matchId": "2157f9e2-9232-4602-86de-a9a24d123eec",
         "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/2157f9e2-9232-4602-86de-a9a24d123eec",
@@ -217,7 +228,9 @@
         ],
         "teamA": "上松",
         "teamB": "植田"
-      },
+      }
+    ],
+    "19": [
       {
         "matchId": "4920c088-0a42-4d49-a224-3c0bf6c28a96",
         "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/4920c088-0a42-4d49-a224-3c0bf6c28a96",
@@ -228,19 +241,28 @@
         ],
         "teamA": "上松",
         "teamB": "植田"
-      }
-    ],
-    "19": [
+      },
       {
-        "matchId": "37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
-        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
-        "round": "6回戦",
+        "matchId": "4795b5c4-ea33-480a-80ae-96108246806e",
+        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/4795b5c4-ea33-480a-80ae-96108246806e",
+        "round": "決勝",
         "entryNos": [
           1,
-          36
+          145
         ],
         "teamA": "上松",
-        "teamB": "黒坂"
+        "teamB": "橋場"
+      },
+      {
+        "matchId": "4c7e9057-cc57-4104-a2bc-e173508a251f",
+        "detailPath": "/tournaments/all/zennihon-championship/2024/doubles/none/boys/matches/4c7e9057-cc57-4104-a2bc-e173508a251f",
+        "round": "決勝",
+        "entryNos": [
+          95,
+          189
+        ],
+        "teamA": "内本・内田",
+        "teamB": "船水・上松"
       },
       {
         "matchId": "3e2fbc9c-cb76-4e7a-be95-8961103437ae",
@@ -249,17 +271,6 @@
         "entryNos": [
           1,
           127
-        ],
-        "teamA": "上松",
-        "teamB": "植田"
-      },
-      {
-        "matchId": "4920c088-0a42-4d49-a224-3c0bf6c28a96",
-        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/4920c088-0a42-4d49-a224-3c0bf6c28a96",
-        "round": "決勝",
-        "entryNos": [
-          1,
-          156
         ],
         "teamA": "上松",
         "teamB": "植田"
@@ -276,15 +287,15 @@
         "teamB": "黒坂"
       },
       {
-        "matchId": "4795b5c4-ea33-480a-80ae-96108246806e",
-        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/4795b5c4-ea33-480a-80ae-96108246806e",
-        "round": "決勝",
+        "matchId": "37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
+        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
+        "round": "6回戦",
         "entryNos": [
           1,
-          145
+          36
         ],
         "teamA": "上松",
-        "teamB": "橋場"
+        "teamB": "黒坂"
       },
       {
         "matchId": "4b74d0c4-0d78-4d7d-a3db-6f70d64881ef",
@@ -296,20 +307,20 @@
         ],
         "teamA": "内本・上松",
         "teamB": "辻浦・福島"
-      },
-      {
-        "matchId": "4c7e9057-cc57-4104-a2bc-e173508a251f",
-        "detailPath": "/tournaments/all/zennihon-championship/2024/doubles/none/boys/matches/4c7e9057-cc57-4104-a2bc-e173508a251f",
-        "round": "決勝",
-        "entryNos": [
-          95,
-          189
-        ],
-        "teamA": "内本・内田",
-        "teamB": "船水・上松"
       }
     ],
     "20": [
+      {
+        "matchId": "eb0cffa2-1acb-4167-8bfa-6e670f7d1c21",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/eb0cffa2-1acb-4167-8bfa-6e670f7d1c21",
+        "round": "決勝",
+        "entryNos": [
+          49,
+          196
+        ],
+        "teamA": "橋場・菊山",
+        "teamB": "上岡・丸山"
+      },
       {
         "matchId": "2157f9e2-9232-4602-86de-a9a24d123eec",
         "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/2157f9e2-9232-4602-86de-a9a24d123eec",
@@ -331,17 +342,6 @@
         ],
         "teamA": "塚本",
         "teamB": "上岡"
-      },
-      {
-        "matchId": "eb0cffa2-1acb-4167-8bfa-6e670f7d1c21",
-        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/eb0cffa2-1acb-4167-8bfa-6e670f7d1c21",
-        "round": "決勝",
-        "entryNos": [
-          49,
-          196
-        ],
-        "teamA": "橋場・菊山",
-        "teamB": "上岡・丸山"
       },
       {
         "matchId": "5155b158-3db3-41b9-9062-161dceeb0d34",

--- a/public/data/beta-matches/reverse/by-tournament.json
+++ b/public/data/beta-matches/reverse/by-tournament.json
@@ -1,0 +1,169 @@
+{
+  "generatedAt": "2026-06-13T02:40:58.069Z",
+  "tournaments": {
+    "/tournaments/all/zennihon-singles/2026/singles/none/boys": [
+      {
+        "matchId": "2157f9e2-9232-4602-86de-a9a24d123eec",
+        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/2157f9e2-9232-4602-86de-a9a24d123eec",
+        "round": "準決勝",
+        "entryNos": [
+          156,
+          271
+        ],
+        "teamA": "植田",
+        "teamB": "上岡"
+      },
+      {
+        "matchId": "31e4715d-c98e-4992-a9ce-e3831c38ec9b",
+        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/31e4715d-c98e-4992-a9ce-e3831c38ec9b",
+        "round": "準々決勝",
+        "entryNos": [
+          239,
+          271
+        ],
+        "teamA": "塚本",
+        "teamB": "上岡"
+      },
+      {
+        "matchId": "4920c088-0a42-4d49-a224-3c0bf6c28a96",
+        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/4920c088-0a42-4d49-a224-3c0bf6c28a96",
+        "round": "決勝",
+        "entryNos": [
+          1,
+          156
+        ],
+        "teamA": "上松",
+        "teamB": "植田"
+      },
+      {
+        "matchId": "5adccffc-9645-4cbb-82e8-58e589cf2f94",
+        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/5adccffc-9645-4cbb-82e8-58e589cf2f94",
+        "round": "準々決勝",
+        "entryNos": [
+          1,
+          40
+        ],
+        "teamA": "上松",
+        "teamB": "黒坂"
+      },
+      {
+        "matchId": "7ac789f6-096e-47e1-9af8-9031d4175efc",
+        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/7ac789f6-096e-47e1-9af8-9031d4175efc",
+        "round": "4回戦",
+        "entryNos": [
+          14,
+          18
+        ],
+        "teamA": "広光",
+        "teamB": "白川"
+      }
+    ],
+    "/tournaments/all/zennihon-singles/2025/singles/none/boys": [
+      {
+        "matchId": "37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
+        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
+        "round": "6回戦",
+        "entryNos": [
+          1,
+          36
+        ],
+        "teamA": "上松",
+        "teamB": "黒坂"
+      },
+      {
+        "matchId": "3e2fbc9c-cb76-4e7a-be95-8961103437ae",
+        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/3e2fbc9c-cb76-4e7a-be95-8961103437ae",
+        "round": "準決勝",
+        "entryNos": [
+          1,
+          127
+        ],
+        "teamA": "上松",
+        "teamB": "植田"
+      },
+      {
+        "matchId": "4795b5c4-ea33-480a-80ae-96108246806e",
+        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/4795b5c4-ea33-480a-80ae-96108246806e",
+        "round": "決勝",
+        "entryNos": [
+          1,
+          145
+        ],
+        "teamA": "上松",
+        "teamB": "橋場"
+      }
+    ],
+    "/tournaments/all/zennihon-championship/2025/doubles/none/boys": [
+      {
+        "matchId": "eb0cffa2-1acb-4167-8bfa-6e670f7d1c21",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/eb0cffa2-1acb-4167-8bfa-6e670f7d1c21",
+        "round": "決勝",
+        "entryNos": [
+          49,
+          196
+        ],
+        "teamA": "橋場・菊山",
+        "teamB": "上岡・丸山"
+      },
+      {
+        "matchId": "701fa50b-78d0-4e89-98f5-e82161b0ef19",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/701fa50b-78d0-4e89-98f5-e82161b0ef19",
+        "round": "3回戦",
+        "entryNos": [
+          92,
+          98
+        ],
+        "teamA": "橋本・増田",
+        "teamB": "片岡・黒坂"
+      },
+      {
+        "matchId": "5155b158-3db3-41b9-9062-161dceeb0d34",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/5155b158-3db3-41b9-9062-161dceeb0d34",
+        "round": "2回戦",
+        "entryNos": [
+          194,
+          196
+        ],
+        "teamA": "酒井・前道",
+        "teamB": "上岡・丸山"
+      },
+      {
+        "matchId": "4b74d0c4-0d78-4d7d-a3db-6f70d64881ef",
+        "detailPath": "/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/4b74d0c4-0d78-4d7d-a3db-6f70d64881ef",
+        "round": "2回戦",
+        "entryNos": [
+          1,
+          2
+        ],
+        "teamA": "内本・上松",
+        "teamB": "辻浦・福島"
+      }
+    ],
+    "/tournaments/university/zennihon-university/2025/doubles/none/boys": [
+      {
+        "matchId": "16de8dd3-e117-4c20-9f51-17db8a848b87",
+        "detailPath": "/tournaments/university/zennihon-university/2025/doubles/none/boys/matches/16de8dd3-e117-4c20-9f51-17db8a848b87",
+        "round": "6回戦",
+        "entryNos": [
+          284,
+          318
+        ],
+        "teamA": "片岡・黒坂",
+        "teamB": "清水・宮田"
+      }
+    ],
+    "/tournaments/all/zennihon-championship/2024/doubles/none/boys": [
+      {
+        "matchId": "4c7e9057-cc57-4104-a2bc-e173508a251f",
+        "detailPath": "/tournaments/all/zennihon-championship/2024/doubles/none/boys/matches/4c7e9057-cc57-4104-a2bc-e173508a251f",
+        "round": "決勝",
+        "entryNos": [
+          95,
+          189
+        ],
+        "teamA": "内本・内田",
+        "teamB": "船水・上松"
+      }
+    ]
+  }
+}

--- a/public/data/beta-matches/reverse/by-tournament.json
+++ b/public/data/beta-matches/reverse/by-tournament.json
@@ -1,7 +1,18 @@
 {
-  "generatedAt": "2026-06-13T02:40:58.069Z",
+  "generatedAt": "2026-06-13T04:45:06.650Z",
   "tournaments": {
     "/tournaments/all/zennihon-singles/2026/singles/none/boys": [
+      {
+        "matchId": "4920c088-0a42-4d49-a224-3c0bf6c28a96",
+        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/4920c088-0a42-4d49-a224-3c0bf6c28a96",
+        "round": "決勝",
+        "entryNos": [
+          1,
+          156
+        ],
+        "teamA": "上松",
+        "teamB": "植田"
+      },
       {
         "matchId": "2157f9e2-9232-4602-86de-a9a24d123eec",
         "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/2157f9e2-9232-4602-86de-a9a24d123eec",
@@ -23,17 +34,6 @@
         ],
         "teamA": "塚本",
         "teamB": "上岡"
-      },
-      {
-        "matchId": "4920c088-0a42-4d49-a224-3c0bf6c28a96",
-        "detailPath": "/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/4920c088-0a42-4d49-a224-3c0bf6c28a96",
-        "round": "決勝",
-        "entryNos": [
-          1,
-          156
-        ],
-        "teamA": "上松",
-        "teamB": "植田"
       },
       {
         "matchId": "5adccffc-9645-4cbb-82e8-58e589cf2f94",
@@ -60,15 +60,15 @@
     ],
     "/tournaments/all/zennihon-singles/2025/singles/none/boys": [
       {
-        "matchId": "37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
-        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
-        "round": "6回戦",
+        "matchId": "4795b5c4-ea33-480a-80ae-96108246806e",
+        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/4795b5c4-ea33-480a-80ae-96108246806e",
+        "round": "決勝",
         "entryNos": [
           1,
-          36
+          145
         ],
         "teamA": "上松",
-        "teamB": "黒坂"
+        "teamB": "橋場"
       },
       {
         "matchId": "3e2fbc9c-cb76-4e7a-be95-8961103437ae",
@@ -82,15 +82,15 @@
         "teamB": "植田"
       },
       {
-        "matchId": "4795b5c4-ea33-480a-80ae-96108246806e",
-        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/4795b5c4-ea33-480a-80ae-96108246806e",
-        "round": "決勝",
+        "matchId": "37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
+        "detailPath": "/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/37f9acb5-29c1-4259-b2e1-d443fbcad6ee",
+        "round": "6回戦",
         "entryNos": [
           1,
-          145
+          36
         ],
         "teamA": "上松",
-        "teamB": "橋場"
+        "teamB": "黒坂"
       }
     ],
     "/tournaments/all/zennihon-championship/2025/doubles/none/boys": [

--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
 <url><loc>https://softeni-pick.com/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://softeni-pick.com/about/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://softeni-pick.com/contact/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://softeni-pick.com/faq/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/highschool/boys/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/highschool/boys/aichi/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/highschool/boys/aichi/aisanoomikawa/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
@@ -2531,12 +2528,9 @@
 <url><loc>https://softeni-pick.com/players/ueoka-shunsuke/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/players/yano-soto/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/players/yonekawa-yuto/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://softeni-pick.com/privacy/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://softeni-pick.com/st-league/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/st-league/2025/analysis/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/st-league/2025/matches/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/st-league/2025/teams/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
-<url><loc>https://softeni-pick.com/st-league/about/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/teams/nssu/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/teams/nssu/2022/boys/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/teams/nssu/2022/girls/</loc><changefreq>weekly</changefreq><priority>0.7</priority></url>
@@ -2574,8 +2568,13 @@
 <url><loc>https://softeni-pick.com/tournaments/all/zennihon-championship/2023/doubles/none/boys/</loc><lastmod>2023-11-19</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/all/zennihon-championship/2023/doubles/none/girls/</loc><lastmod>2023-11-19</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/all/zennihon-championship/2024/doubles/none/boys/</loc><lastmod>2024-11-10</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://softeni-pick.com/tournaments/all/zennihon-championship/2024/doubles/none/boys/matches/4c7e9057-cc57-4104-a2bc-e173508a251f/</loc><lastmod>2024-11-10</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/all/zennihon-championship/2024/doubles/none/girls/</loc><lastmod>2024-11-10</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/all/zennihon-championship/2025/doubles/none/boys/</loc><lastmod>2025-11-08</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://softeni-pick.com/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/4b74d0c4-0d78-4d7d-a3db-6f70d64881ef/</loc><lastmod>2025-11-08</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://softeni-pick.com/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/5155b158-3db3-41b9-9062-161dceeb0d34/</loc><lastmod>2025-11-08</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://softeni-pick.com/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/701fa50b-78d0-4e89-98f5-e82161b0ef19/</loc><lastmod>2025-11-08</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://softeni-pick.com/tournaments/all/zennihon-championship/2025/doubles/none/boys/matches/eb0cffa2-1acb-4167-8bfa-6e670f7d1c21/</loc><lastmod>2025-11-08</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/all/zennihon-championship/2025/doubles/none/girls/</loc><lastmod>2025-11-08</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/all/zennihon-indoor/2022/doubles/none/boys/</loc><lastmod>2023-02-05</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/all/zennihon-indoor/2022/doubles/none/girls/</loc><lastmod>2023-02-05</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
@@ -2608,8 +2607,16 @@
 <url><loc>https://softeni-pick.com/tournaments/all/zennihon-singles/2024/singles/none/boys/</loc><lastmod>2024-05-19</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/all/zennihon-singles/2024/singles/none/girls/</loc><lastmod>2024-05-19</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/all/zennihon-singles/2025/singles/none/boys/</loc><lastmod>2025-05-18</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://softeni-pick.com/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/37f9acb5-29c1-4259-b2e1-d443fbcad6ee/</loc><lastmod>2026-05-18T14:56:33.848+00:00</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://softeni-pick.com/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/3e2fbc9c-cb76-4e7a-be95-8961103437ae/</loc><lastmod>2026-05-18T14:33:49.805+00:00</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://softeni-pick.com/tournaments/all/zennihon-singles/2025/singles/none/boys/matches/4795b5c4-ea33-480a-80ae-96108246806e/</loc><lastmod>2025-05-18</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/all/zennihon-singles/2025/singles/none/girls/</loc><lastmod>2025-05-18</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/all/zennihon-singles/2026/singles/none/boys/</loc><lastmod>2026-05-17</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://softeni-pick.com/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/2157f9e2-9232-4602-86de-a9a24d123eec/</loc><lastmod>2026-05-22T15:22:11.663+00:00</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://softeni-pick.com/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/31e4715d-c98e-4992-a9ce-e3831c38ec9b/</loc><lastmod>2026-05-22T04:41:07.733+00:00</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://softeni-pick.com/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/4920c088-0a42-4d49-a224-3c0bf6c28a96/</loc><lastmod>2026-05-17</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://softeni-pick.com/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/5adccffc-9645-4cbb-82e8-58e589cf2f94/</loc><lastmod>2026-05-17</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://softeni-pick.com/tournaments/all/zennihon-singles/2026/singles/none/boys/matches/7ac789f6-096e-47e1-9af8-9031d4175efc/</loc><lastmod>2026-05-17</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/all/zennihon-singles/2026/singles/none/girls/</loc><lastmod>2026-05-17</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/corporate/zennihon-business-group/2025/team/none/boys/</loc><lastmod>2025-07-27</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/corporate/zennihon-business-group/2025/team/none/girls/</loc><lastmod>2025-07-27</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
@@ -2859,6 +2866,7 @@
 <url><loc>https://softeni-pick.com/tournaments/university/zennihon-university/2024/singles/none/boys/</loc><lastmod>2024-09-15</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/university/zennihon-university/2024/singles/none/girls/</loc><lastmod>2024-09-15</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/university/zennihon-university/2025/doubles/none/boys/</loc><lastmod>2025-09-03</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
+<url><loc>https://softeni-pick.com/tournaments/university/zennihon-university/2025/doubles/none/boys/matches/16de8dd3-e117-4c20-9f51-17db8a848b87/</loc><lastmod>2025-09-03</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/university/zennihon-university/2025/doubles/none/girls/</loc><lastmod>2025-09-03</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/university/zennihon-university/2025/singles/none/boys/</loc><lastmod>2025-09-03</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>
 <url><loc>https://softeni-pick.com/tournaments/university/zennihon-university/2025/singles/none/girls/</loc><lastmod>2025-09-03</lastmod><changefreq>weekly</changefreq><priority>0.7</priority></url>

--- a/scripts/generate-beta-matches-json.mjs
+++ b/scripts/generate-beta-matches-json.mjs
@@ -6,6 +6,8 @@ import { fileURLToPath } from 'url';
 import nextEnv from '@next/env';
 import { createClient } from '@supabase/supabase-js';
 
+import { resolveMatchSiteLink } from '../lib/siteLink.mjs';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const projectRoot = path.resolve(__dirname, '..');
@@ -13,7 +15,7 @@ const outputRoot = path.join(projectRoot, 'public', 'data', 'beta-matches');
 const matchesOutputRoot = path.join(outputRoot, 'matches');
 const growthOutputRoot = path.join(outputRoot, 'growth');
 const growthReportsOutputRoot = path.join(growthOutputRoot, 'reports');
-const LATEST_BETA_MATCH_LIMIT = 50;
+const detailsRoot = path.join(projectRoot, 'data', 'tournaments', 'details');
 const { loadEnvConfig } = nextEnv;
 const require = createRequire(import.meta.url);
 
@@ -86,10 +88,12 @@ const getSupabaseConfig = () => {
   };
 };
 
-const ensureCleanDir = (dirPath) => {
-  fs.rmSync(dirPath, { recursive: true, force: true });
-  fs.mkdirSync(dirPath, { recursive: true });
-};
+// 掲載大会に紐づく試合へ siteLink をベイクする（野良試合は null）。
+// 仕様: docs/wiki/score-site-link.md
+const enrichWithSiteLink = (match) => ({
+  ...match,
+  siteLink: resolveMatchSiteLink(match, { detailsRoot }) ?? null,
+});
 
 const readJsonIfExists = (filePath) => {
   if (!fs.existsSync(filePath)) return null;
@@ -303,49 +307,9 @@ const attachGamesToMatches = async (supabase, matches) => {
   }));
 };
 
-const buildBetaMatchesJson = async () => {
-  console.log('Starting beta matches JSON generation...');
-
-  const config = getSupabaseConfig();
-  if (!config) {
-    if (hasExistingSnapshot()) {
-      console.warn(
-        'Supabase env is missing. Reusing committed beta matches JSON snapshot.',
-      );
-      const generatedAt = new Date().toISOString();
-      const snapshotMatches = loadExistingSnapshotMatches();
-      const growthStats = buildGrowthAnalysisJson(snapshotMatches, generatedAt);
-      console.log(
-        `✓ Generated growth JSON from snapshot (${growthStats.reportCount}/${growthStats.targetCount} reports)`,
-      );
-      return;
-    }
-
-    throw new Error(
-      'Supabase env is missing and no beta matches JSON snapshot exists.',
-    );
-  }
-
-  const supabase = createClient(config.url, config.serviceKey, {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false,
-    },
-  });
-
-  const { data: matches, error } = await supabase
-    .from('matches')
-    .select('*')
-    .order('created_at', { ascending: false })
-    .limit(LATEST_BETA_MATCH_LIMIT);
-
-  if (error) {
-    throw error;
-  }
-
-  const safeMatches = await attachGamesToMatches(supabase, matches ?? []);
-  const publicMatches = safeMatches.map(toPublicMatchSnapshot);
-  const generatedAt = new Date().toISOString();
+// 追記型の出力本体。Supabase パス・スナップショット再利用パスの両方から使う。
+// 出力ディレクトリは全削除せず、既存ファイルを更新する（公開 URL 消失を防ぐ）。
+const writeBetaMatchesOutput = (publicMatches, generatedAt) => {
   const matchIds = publicMatches.map((match) => match.id);
   const summaryMatches = publicMatches.map(summarizeMatchForIndex);
   const existingMeta = readJsonIfExists(path.join(outputRoot, 'meta.json'));
@@ -369,7 +333,7 @@ const buildBetaMatchesJson = async () => {
     }),
   );
 
-  ensureCleanDir(outputRoot);
+  fs.mkdirSync(outputRoot, { recursive: true });
   fs.mkdirSync(matchesOutputRoot, { recursive: true });
   fs.mkdirSync(growthOutputRoot, { recursive: true });
 
@@ -379,7 +343,7 @@ const buildBetaMatchesJson = async () => {
       {
         generatedAt,
         matchIds,
-        totalMatches: safeMatches.length,
+        totalMatches: publicMatches.length,
       },
       existingMeta,
     ),
@@ -408,6 +372,7 @@ const buildBetaMatchesJson = async () => {
       ),
     );
   });
+
   const growthStats = buildGrowthAnalysisJson(
     publicMatches,
     generatedAt,
@@ -415,8 +380,65 @@ const buildBetaMatchesJson = async () => {
     existingGrowthReportsByFileName,
   );
 
+  const siteLinkCount = publicMatches.filter((match) => match.siteLink).length;
+  return { growthStats, siteLinkCount };
+};
+
+const buildBetaMatchesJson = async () => {
+  console.log('Starting beta matches JSON generation...');
+
+  const config = getSupabaseConfig();
+  if (!config) {
+    if (hasExistingSnapshot()) {
+      console.warn(
+        'Supabase env is missing. Reusing committed beta matches JSON snapshot.',
+      );
+      const generatedAt = new Date().toISOString();
+      const publicMatches = loadExistingSnapshotMatches().map(enrichWithSiteLink);
+      const { growthStats, siteLinkCount } = writeBetaMatchesOutput(
+        publicMatches,
+        generatedAt,
+      );
+      console.log(
+        `✓ Regenerated beta matches JSON from snapshot (${publicMatches.length} matches, ${siteLinkCount} linked, ${growthStats.reportCount}/${growthStats.targetCount} growth reports)`,
+      );
+      return;
+    }
+
+    throw new Error(
+      'Supabase env is missing and no beta matches JSON snapshot exists.',
+    );
+  }
+
+  const supabase = createClient(config.url, config.serviceKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+
+  const { data: matches, error } = await supabase
+    .from('matches')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw error;
+  }
+
+  const safeMatches = await attachGamesToMatches(supabase, matches ?? []);
+  const publicMatches = safeMatches
+    .map(toPublicMatchSnapshot)
+    .map(enrichWithSiteLink);
+  const generatedAt = new Date().toISOString();
+
+  const { growthStats, siteLinkCount } = writeBetaMatchesOutput(
+    publicMatches,
+    generatedAt,
+  );
+
   console.log(
-    `✓ Generated beta matches JSON (${safeMatches.length} matches, ${growthStats.reportCount}/${growthStats.targetCount} growth reports)`,
+    `✓ Generated beta matches JSON (${publicMatches.length} matches, ${siteLinkCount} linked, ${growthStats.reportCount}/${growthStats.targetCount} growth reports)`,
   );
 };
 

--- a/scripts/generate-match-reverse-index.mjs
+++ b/scripts/generate-match-reverse-index.mjs
@@ -1,0 +1,154 @@
+// 本体ページ（大会・選手）→ 試合詳細 の逆引き表を生成する。
+//
+// 入力: public/data/beta-matches/index.json（siteLink 付き試合サマリ）
+// 出力:
+//   public/data/beta-matches/reverse/by-tournament.json
+//     tournamentPath -> 試合リンク配列
+//   public/data/beta-matches/reverse/by-player.json
+//     playerId(number, 文字列キー) -> 試合リンク配列
+//
+// 掲載大会に紐づく試合（siteLink あり）だけを対象にする。
+// 選手 ID 解決は data/players/index.json（count>=5、同姓同名は最初の ID）に従う。
+// 仕様: docs/wiki/score-site-link.md
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, '..');
+const betaMatchesRoot = path.join(
+  projectRoot,
+  'public',
+  'data',
+  'beta-matches',
+);
+const reverseRoot = path.join(betaMatchesRoot, 'reverse');
+const playersIndexPath = path.join(
+  projectRoot,
+  'data',
+  'players',
+  'index.json',
+);
+
+const readJsonIfExists = (filePath) => {
+  if (!fs.existsSync(filePath)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+};
+
+const writeJson = (filePath, value) => {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+};
+
+// data/tournaments の playerIndexMap と同じ規約（count>=5、同姓同名は最初の ID）
+const buildPlayerIndexMap = () => {
+  const map = new Map();
+  const playersIndex = readJsonIfExists(playersIndexPath);
+  if (!Array.isArray(playersIndex)) return map;
+
+  for (const player of playersIndex) {
+    if (!player || (player.count ?? 0) < 5) continue;
+    const key = `${player.lastName}::${player.firstName}`;
+    if (!map.has(key)) {
+      map.set(key, player.id);
+    }
+  }
+  return map;
+};
+
+const buildTeamDisplayName = (match, side) => {
+  const p1Last = match[`team_${side}_player1_last_name`];
+  const p2Last = match[`team_${side}_player2_last_name`];
+  if (p1Last) {
+    return [p1Last, p2Last].filter(Boolean).join('・');
+  }
+  return match[`team_${side}`] ?? '';
+};
+
+// 試合に含まれる選手（最大 4 名）を { lastName, firstName } で列挙
+const listMatchPlayers = (match) => {
+  const players = [];
+  for (const side of ['a', 'b']) {
+    for (const slot of ['player1', 'player2']) {
+      const lastName = match[`team_${side}_${slot}_last_name`];
+      const firstName = match[`team_${side}_${slot}_first_name`];
+      if (lastName && firstName) {
+        players.push({ lastName, firstName });
+      }
+    }
+  }
+  return players;
+};
+
+const buildReverseIndex = () => {
+  const index = readJsonIfExists(path.join(betaMatchesRoot, 'index.json'));
+  const matches = Array.isArray(index?.matches) ? index.matches : [];
+  const playerIndexMap = buildPlayerIndexMap();
+
+  const byTournament = {};
+  const byPlayer = {};
+
+  for (const match of matches) {
+    const tournamentPath = match.siteLink?.tournamentPath;
+    if (!tournamentPath) continue;
+
+    const detailPath = `${tournamentPath}/matches/${match.id}`;
+    const link = {
+      matchId: match.id,
+      detailPath,
+      round: match.round_name ?? null,
+      entryNos: match.siteLink?.entryNos ?? [],
+      teamA: buildTeamDisplayName(match, 'a'),
+      teamB: buildTeamDisplayName(match, 'b'),
+    };
+
+    (byTournament[tournamentPath] ??= []).push(link);
+
+    const seenPlayerIds = new Set();
+    for (const player of listMatchPlayers(match)) {
+      const playerId = playerIndexMap.get(
+        `${player.lastName}::${player.firstName}`,
+      );
+      if (playerId === undefined) continue;
+      if (seenPlayerIds.has(playerId)) continue;
+      seenPlayerIds.add(playerId);
+
+      (byPlayer[String(playerId)] ??= []).push(link);
+    }
+  }
+
+  return { byTournament, byPlayer };
+};
+
+const main = () => {
+  console.log('Starting match reverse index generation...');
+
+  if (!fs.existsSync(path.join(betaMatchesRoot, 'index.json'))) {
+    console.warn('beta-matches index.json not found. Skipping reverse index.');
+    return;
+  }
+
+  const { byTournament, byPlayer } = buildReverseIndex();
+  const generatedAt = new Date().toISOString();
+
+  fs.mkdirSync(reverseRoot, { recursive: true });
+  writeJson(path.join(reverseRoot, 'by-tournament.json'), {
+    generatedAt,
+    tournaments: byTournament,
+  });
+  writeJson(path.join(reverseRoot, 'by-player.json'), {
+    generatedAt,
+    players: byPlayer,
+  });
+
+  console.log(
+    `✓ Generated match reverse index (${Object.keys(byTournament).length} tournaments, ${Object.keys(byPlayer).length} players)`,
+  );
+};
+
+main();

--- a/scripts/generate-match-reverse-index.mjs
+++ b/scripts/generate-match-reverse-index.mjs
@@ -61,6 +61,24 @@ const buildPlayerIndexMap = () => {
   return map;
 };
 
+// ラウンドの表示順位（小さいほど決勝に近く、リスト先頭に来る）。
+// 決勝 → 準決勝 → 準々決勝 → 6回戦 → 5回戦 → … → 1回戦 → その他
+const roundRank = (roundName) => {
+  if (!roundName) return 1000;
+  if (roundName === '決勝') return 0;
+  if (roundName === '準決勝') return 1;
+  if (roundName === '準々決勝') return 2;
+  const roundMatch = roundName.match(/^(\d+)回戦$/);
+  if (roundMatch) {
+    // 回戦数が大きいほど決勝に近い（6回戦を5回戦より前に）
+    return 100 - Number(roundMatch[1]);
+  }
+  return 1000;
+};
+
+const sortLinksByRound = (links) =>
+  links.sort((a, b) => roundRank(a.round) - roundRank(b.round));
+
 const buildTeamDisplayName = (match, side) => {
   const p1Last = match[`team_${side}_player1_last_name`];
   const p2Last = match[`team_${side}_player2_last_name`];
@@ -121,6 +139,10 @@ const buildReverseIndex = () => {
       (byPlayer[String(playerId)] ??= []).push(link);
     }
   }
+
+  // ラウンド順（決勝→準決勝→準々決勝→…）に並べ替える
+  Object.values(byTournament).forEach(sortLinksByRound);
+  Object.values(byPlayer).forEach(sortLinksByRound);
 
   return { byTournament, byPlayer };
 };

--- a/src/pages/api/tournament-entries.ts
+++ b/src/pages/api/tournament-entries.ts
@@ -1,0 +1,124 @@
+import fs from 'fs';
+import path from 'path';
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+import { isScoreSiteMode } from '@/lib/siteConfig';
+
+// 試合作成画面（dev 専用）向け: 掲載大会のエントリー一覧を返す。
+// data/tournaments/details/{tournamentId}/{year}/{categoryId}.json から
+// entryNo と選手情報を組み立てる。
+// このルートは静的 export には含まれず、開発サーバーでのみ機能する。
+// 仕様: docs/wiki/score-site-link.md
+
+interface EntryOptionPlayer {
+  last_name: string;
+  first_name: string;
+  team_name: string;
+  region: string;
+}
+
+export interface TournamentEntryOption {
+  entryNo: number;
+  label: string;
+  players: EntryOptionPlayer[];
+}
+
+interface DetailParticipant {
+  id: string;
+  lastName?: string;
+  firstName?: string;
+  team?: string;
+  prefecture?: string;
+}
+
+interface DetailEntry {
+  entryNo: number;
+  playerIds?: string[];
+}
+
+const isSafeSegment = (value: string) => /^[\w-]+$/.test(value);
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (isScoreSiteMode()) {
+    return res.status(404).json({ error: 'Not found.' });
+  }
+
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return res.status(405).json({ error: 'Method not allowed.' });
+  }
+
+  const tournamentId = String(req.query.tournamentId ?? '');
+  const year = String(req.query.year ?? '');
+  const categoryId = String(req.query.categoryId ?? '');
+
+  if (!tournamentId || !year || !categoryId) {
+    return res
+      .status(400)
+      .json({ error: 'tournamentId, year, categoryId are required.' });
+  }
+
+  // パストラバーサル対策（外部入力をパスに使うため）
+  if (
+    !isSafeSegment(tournamentId) ||
+    !/^\d{4}$/.test(year) ||
+    !isSafeSegment(categoryId)
+  ) {
+    return res.status(400).json({ error: 'Invalid parameter format.' });
+  }
+
+  const detailPath = path.join(
+    process.cwd(),
+    'data',
+    'tournaments',
+    'details',
+    tournamentId,
+    year,
+    `${categoryId}.json`,
+  );
+
+  if (!fs.existsSync(detailPath)) {
+    return res.status(200).json({ entries: [] });
+  }
+
+  try {
+    const detail = JSON.parse(fs.readFileSync(detailPath, 'utf-8')) as {
+      participants?: DetailParticipant[];
+      entries?: DetailEntry[];
+    };
+
+    const participantById = new Map<string, DetailParticipant>(
+      (detail.participants ?? []).map((participant) => [
+        participant.id,
+        participant,
+      ]),
+    );
+
+    const entries: TournamentEntryOption[] = (detail.entries ?? [])
+      .map((entry) => {
+        const players: EntryOptionPlayer[] = (entry.playerIds ?? [])
+          .map((id) => participantById.get(id))
+          .filter((p): p is DetailParticipant => Boolean(p))
+          .map((p) => ({
+            last_name: p.lastName ?? '',
+            first_name: p.firstName ?? '',
+            team_name: p.team ?? '',
+            region: p.prefecture ?? '',
+          }));
+
+        const label = `${entry.entryNo} ${players
+          .map((p) => `${p.last_name}${p.first_name}`)
+          .join('・')}`;
+
+        return { entryNo: entry.entryNo, label, players };
+      })
+      .filter((entry) => entry.players.length > 0)
+      .sort((a, b) => a.entryNo - b.entryNo);
+
+    return res.status(200).json({ entries });
+  } catch (error) {
+    console.error('Failed to load tournament entries:', error);
+    return res.status(500).json({ error: 'Failed to load entries.' });
+  }
+}

--- a/src/pages/beta/matches-results/[matchId]/index.tsx
+++ b/src/pages/beta/matches-results/[matchId]/index.tsx
@@ -1470,7 +1470,7 @@ export const PublicMatchDetailPage = ({
       <MetaHead
         title={`${getShortTeamName('A')} vs ${getShortTeamName('B')} 試合詳細`}
         description="ポイント詳細記録から、試合の流れと分析結果を確認できます。"
-        url={buildSiteUrl(getPublicMatchDetailPath(match.id))}
+        url={buildSiteUrl(getPublicMatchDetailPath(match))}
         type="article"
       />
       <div className="mx-auto max-w-6xl bg-white p-6 text-gray-800 dark:bg-gray-900 dark:text-gray-100">

--- a/src/pages/beta/matches-results/index.tsx
+++ b/src/pages/beta/matches-results/index.tsx
@@ -121,7 +121,7 @@ export function PublicMatchesListPage({ matches, tournamentInfos }: Props) {
               {matches.map((match) => (
                 <li key={match.id} className="relative">
                   <Link
-                    href={getPublicMatchDetailPath(match.id)}
+                    href={getPublicMatchDetailPath(match)}
                     className="block p-4 transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/60"
                     aria-label={`${getBetaTeamDisplayName(
                       match,

--- a/src/pages/beta/matches/create.tsx
+++ b/src/pages/beta/matches/create.tsx
@@ -22,6 +22,17 @@ type TournamentCatalogEntry = {
   meta: TournamentMeta | null;
 };
 
+type EntryOption = {
+  entryNo: number;
+  label: string;
+  players: {
+    last_name: string;
+    first_name: string;
+    team_name: string;
+    region: string;
+  }[];
+};
+
 type CreateMatchProps = {
   tournamentOptions: TournamentOption[];
   tournamentCatalog: Record<string, TournamentCatalogEntry>;
@@ -112,6 +123,74 @@ const CreateMatch = ({
   });
 
   const [creating, setCreating] = useState(false);
+
+  // 掲載大会のエントリー候補（dev 専用 API から取得）。
+  // 選択すると entry_number / 選手情報を自動入力し、siteLink の解決精度を上げる。
+  // 仕様: docs/wiki/score-site-link.md
+  const [entryOptions, setEntryOptions] = useState<EntryOption[]>([]);
+
+  // 選択中カテゴリの categoryId（ファイル名規約 {category}-{age}-{gender}）を解決
+  const currentCategoryId = (() => {
+    const selected = tournamentCatalog[formData.tournament_name];
+    if (!selected) return '';
+    const matched = selected.categories.find(
+      (cat) =>
+        cat.category === formData.category && cat.gender === formData.gender,
+    );
+    return matched?.id ?? '';
+  })();
+
+  // カテゴリ確定時にエントリー候補を取得
+  useEffect(() => {
+    if (!formData.tournament_name || !currentCategoryId) {
+      setEntryOptions([]);
+      return;
+    }
+
+    const tournamentId = formData.tournament_name.replace(/-\d{4}$/, '');
+    let cancelled = false;
+
+    fetch(
+      `/api/tournament-entries?tournamentId=${encodeURIComponent(
+        tournamentId,
+      )}&year=${formData.year}&categoryId=${encodeURIComponent(
+        currentCategoryId,
+      )}`,
+    )
+      .then((response) => (response.ok ? response.json() : { entries: [] }))
+      .then((data) => {
+        if (!cancelled) setEntryOptions(data.entries ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setEntryOptions([]);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [formData.tournament_name, formData.year, currentCategoryId]);
+
+  // エントリー候補を選手フォームへ反映（手入力フィールドは編集可能なまま）
+  const applyEntryToTeam = (side: 'A' | 'B', option: EntryOption | null) => {
+    if (!option) return;
+    const [p1, p2] = option.players;
+    const nextTeam = {
+      entry_number: String(option.entryNo),
+      player1_last_name: p1?.last_name ?? '',
+      player1_first_name: p1?.first_name ?? '',
+      player1_team_name: p1?.team_name ?? '',
+      player1_region: p1?.region ?? '',
+      player2_last_name: p2?.last_name ?? '',
+      player2_first_name: p2?.first_name ?? '',
+      player2_team_name: p2?.team_name ?? '',
+      player2_region: p2?.region ?? '',
+    };
+    if (side === 'A') {
+      setTeamA(nextTeam);
+    } else {
+      setTeamB(nextTeam);
+    }
+  };
 
   // 大会選択時にカテゴリと年を取得
   useEffect(() => {
@@ -580,6 +659,32 @@ const CreateMatch = ({
 
         <div>
           <label className="block text-sm font-medium mb-4">チームA</label>
+          {entryOptions.length > 0 && (
+            <div className="mb-4">
+              <label className="block text-xs text-emerald-700 mb-1">
+                エントリーから選択（自動入力）
+              </label>
+              <select
+                value=""
+                onChange={(e) =>
+                  applyEntryToTeam(
+                    'A',
+                    entryOptions.find(
+                      (option) => String(option.entryNo) === e.target.value,
+                    ) ?? null,
+                  )
+                }
+                className="w-full border border-emerald-300 rounded p-2 text-sm bg-emerald-50"
+              >
+                <option value="">エントリーを選択…</option>
+                {entryOptions.map((option) => (
+                  <option key={option.entryNo} value={option.entryNo}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
           <div className="mb-4">
             <label className="block text-xs text-gray-600 mb-1">
               エントリー番号
@@ -704,6 +809,32 @@ const CreateMatch = ({
 
         <div>
           <label className="block text-sm font-medium mb-4">チームB</label>
+          {entryOptions.length > 0 && (
+            <div className="mb-4">
+              <label className="block text-xs text-emerald-700 mb-1">
+                エントリーから選択（自動入力）
+              </label>
+              <select
+                value=""
+                onChange={(e) =>
+                  applyEntryToTeam(
+                    'B',
+                    entryOptions.find(
+                      (option) => String(option.entryNo) === e.target.value,
+                    ) ?? null,
+                  )
+                }
+                className="w-full border border-emerald-300 rounded p-2 text-sm bg-emerald-50"
+              >
+                <option value="">エントリーを選択…</option>
+                {entryOptions.map((option) => (
+                  <option key={option.entryNo} value={option.entryNo}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
           <div className="mb-4">
             <label className="block text-xs text-gray-600 mb-1">
               エントリー番号

--- a/src/pages/players/[id]/results.tsx
+++ b/src/pages/players/[id]/results.tsx
@@ -15,6 +15,10 @@ import PlayerSummaryStats from '@/components/PlayerSummaryStats';
 import PageLayout from '@/components/PageLayout';
 import { getMajorTitlesForPlayer, MajorTitleData } from '@/lib/majorTitles';
 import {
+  getScoreMatchLinksForPlayer,
+  type ScoreMatchLink,
+} from '@/lib/matchReverseIndex';
+import {
   getAllDetailRecords,
   loadInformationMap,
   loadTournamentIndex,
@@ -39,6 +43,7 @@ type PlayerResultsProps = {
   majorTitlesData: MajorTitleData[];
   playerStats?: import('@/types/stats').PlayerStats | null;
   allPlayers?: import('@/types/player').PlayerInfo[];
+  scoreMatchLinks?: ScoreMatchLink[];
 };
 
 export default function PlayerResultsPage({
@@ -54,6 +59,7 @@ export default function PlayerResultsPage({
   majorTitlesData,
   playerStats,
   allPlayers,
+  scoreMatchLinks = [],
 }: PlayerResultsProps) {
   const fullName = `${lastName}${firstName}`;
   const pageUrl = `https://softeni-pick.com/players/${playerId}/results/`;
@@ -244,6 +250,39 @@ export default function PlayerResultsPage({
             />
           )}
         </section>
+
+        {scoreMatchLinks.length > 0 && (
+          <section className="rounded-lg border border-emerald-200 bg-emerald-50/60 p-4 dark:border-emerald-900 dark:bg-emerald-950/30">
+            <h2 className="mb-2 text-base font-bold text-emerald-900 dark:text-emerald-200">
+              スコア詳細のある試合
+            </h2>
+            <p className="mb-3 text-xs text-emerald-800/80 dark:text-emerald-300/80">
+              ポイントごとの記録・分析を掲載しています。
+            </p>
+            <ul className="divide-y divide-emerald-200/70 dark:divide-emerald-900/60">
+              {scoreMatchLinks.map((link) => (
+                <li key={link.matchId}>
+                  <Link
+                    href={link.detailPath}
+                    className="flex items-center gap-2 py-2 text-sm text-emerald-900 transition-colors hover:text-emerald-700 dark:text-emerald-100 dark:hover:text-emerald-300"
+                  >
+                    {link.round && (
+                      <span className="shrink-0 rounded bg-emerald-200 px-1.5 py-0.5 text-xs font-semibold text-emerald-900 dark:bg-emerald-800 dark:text-emerald-100">
+                        {link.round}
+                      </span>
+                    )}
+                    <span className="font-medium">
+                      {link.teamA} vs {link.teamB}
+                    </span>
+                    <span aria-hidden className="ml-auto text-emerald-500">
+                      ›
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
 
         <section>
           <PlayerResults
@@ -899,6 +938,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
         idx.lastName,
         idx.firstName,
       ),
+      scoreMatchLinks: getScoreMatchLinksForPlayer(playerId),
     },
   };
 };

--- a/src/pages/tournaments/[generation]/[tournamentId]/[year]/[gameCategory]/[ageCategory]/[gender]/index.tsx
+++ b/src/pages/tournaments/[generation]/[tournamentId]/[year]/[gameCategory]/[ageCategory]/[gender]/index.tsx
@@ -20,6 +20,10 @@ import {
   unpackTournamentDetailData,
 } from '@/lib/packedPageData';
 import {
+  getScoreMatchLinksForTournament,
+  type ScoreMatchLink,
+} from '@/lib/matchReverseIndex';
+import {
   TournamentDetailData,
   TournamentIndexEntry,
   TournamentInformationEntry,
@@ -56,6 +60,7 @@ interface TournamentYearResultPageProps {
   federationId?: string | null;
   highschoolTeamLinks?: Record<string, HighschoolTeamLink> | null;
   prefectureName?: string | null;
+  scoreMatchLinks?: ScoreMatchLink[];
 }
 
 export default function TournamentYearResultPage({
@@ -75,6 +80,7 @@ export default function TournamentYearResultPage({
   federationId = null,
   highschoolTeamLinks = null,
   prefectureName = null,
+  scoreMatchLinks = [],
 }: TournamentYearResultPageProps) {
   const pageUrl = `https://softeni-pick.com/tournaments/${generation}/${tournamentId}/${year}/${gameCategory}/${ageCategory}/${gender}/`;
 
@@ -178,6 +184,40 @@ export default function TournamentYearResultPage({
 
         {/* ✅ トーナメント表 */}
         {detailData && <TournamentBracket detailData={detailData} />}
+
+        {/* ✅ スコア詳細（ポイント分析つき試合） */}
+        {scoreMatchLinks.length > 0 && (
+          <section className="mb-6 rounded-lg border border-emerald-200 bg-emerald-50/60 p-4 dark:border-emerald-900 dark:bg-emerald-950/30">
+            <h2 className="mb-2 text-base font-bold text-emerald-900 dark:text-emerald-200">
+              スコア詳細のある試合
+            </h2>
+            <p className="mb-3 text-xs text-emerald-800/80 dark:text-emerald-300/80">
+              ポイントごとの記録・分析を掲載しています。
+            </p>
+            <ul className="divide-y divide-emerald-200/70 dark:divide-emerald-900/60">
+              {scoreMatchLinks.map((link) => (
+                <li key={link.matchId}>
+                  <Link
+                    href={link.detailPath}
+                    className="flex items-center gap-2 py-2 text-sm text-emerald-900 transition-colors hover:text-emerald-700 dark:text-emerald-100 dark:hover:text-emerald-300"
+                  >
+                    {link.round && (
+                      <span className="shrink-0 rounded bg-emerald-200 px-1.5 py-0.5 text-xs font-semibold text-emerald-900 dark:bg-emerald-800 dark:text-emerald-100">
+                        {link.round}
+                      </span>
+                    )}
+                    <span className="font-medium">
+                      {link.teamA} vs {link.teamB}
+                    </span>
+                    <span aria-hidden className="ml-auto text-emerald-500">
+                      ›
+                    </span>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
 
         {/* ✅ チーム別成績 */}
         <TeamResults
@@ -670,6 +710,10 @@ export const getStaticProps: GetStaticProps = async (context) => {
     }
   }
 
+  // 掲載大会 → 試合詳細（score 系）の逆引きリンク
+  const tournamentPath = `/tournaments/${generation}/${tournamentId}/${year}/${gameCategory}/${ageCategory}/${gender}`;
+  const scoreMatchLinks = getScoreMatchLinksForTournament(tournamentPath);
+
   return {
     props: ((): Record<string, unknown> => {
       return {
@@ -695,6 +739,7 @@ export const getStaticProps: GetStaticProps = async (context) => {
         federationId,
         highschoolTeamLinks,
         prefectureName,
+        scoreMatchLinks,
       };
     })(),
   };

--- a/src/pages/tournaments/[generation]/[tournamentId]/[year]/[gameCategory]/[ageCategory]/[gender]/matches/[matchId].tsx
+++ b/src/pages/tournaments/[generation]/[tournamentId]/[year]/[gameCategory]/[ageCategory]/[gender]/matches/[matchId].tsx
@@ -1,0 +1,47 @@
+import type { GetStaticPaths, GetStaticProps } from 'next';
+
+import {
+  getPublicMatchDetailStaticProps,
+  PublicMatchDetailPage,
+} from '@/pages/beta/matches-results/[matchId]';
+import { getSiteLinkedMatchPaths } from '@/lib/betaMatchesStatic';
+import { isScoreSiteMode } from '@/lib/siteConfig';
+
+// 掲載大会に紐づく試合の indexable な公開面。
+// 試合詳細コンポーネントは /beta/matches-results/[matchId] と共通。
+// canonical / OGP は siteLink により本ネスト URL を向く（lib/siteConfig getPublicMatchDetailPath）。
+// 仕様: docs/wiki/score-site-link.md
+export const getStaticPaths: GetStaticPaths = async () => {
+  // score モードは大会ページ群を持たないためネスト URL を生成しない。
+  if (isScoreSiteMode()) {
+    return { paths: [], fallback: false };
+  }
+
+  const siteLinked = await getSiteLinkedMatchPaths();
+
+  return {
+    paths: siteLinked.map((segment) => ({
+      params: {
+        generation: segment.generation,
+        tournamentId: segment.tournamentId,
+        year: segment.year,
+        gameCategory: segment.gameCategory,
+        ageCategory: segment.ageCategory,
+        gender: segment.gender,
+        matchId: segment.matchId,
+      },
+    })),
+    fallback: false,
+  };
+};
+
+// params.matchId のみ使う（getPublicMatchDetailStaticProps が試合 ID で解決する）。
+export const getStaticProps: GetStaticProps = async (context) => {
+  if (isScoreSiteMode()) {
+    return { notFound: true };
+  }
+
+  return getPublicMatchDetailStaticProps(context);
+};
+
+export default PublicMatchDetailPage;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -10,6 +10,14 @@ export interface MatchTeam {
   players: MatchPlayer[];
 }
 
+// 掲載大会への相互リンク用（公開 JSON にのみ存在する派生フィールド）
+// 生成は lib/siteLink.mjs / scripts/generate-beta-matches-json.mjs
+// 仕様は docs/wiki/score-site-link.md
+export interface MatchSiteLink {
+  tournamentPath: string;
+  entryNos: number[];
+}
+
 export interface Match {
   id: string;
   tournament_name: string | null;
@@ -32,6 +40,9 @@ export interface Match {
   opponent_level?: 'stronger' | 'same' | 'weaker' | 'unknown' | null;
   source_site_match_id?: string | null;
   source_site_tournament_id?: string | null;
+
+  // 掲載大会への相互リンク（公開 JSON 生成時にベイクされる派生フィールド）
+  siteLink?: MatchSiteLink | null;
 
   // 個別フィールド（新形式）
   team_a_entry_number?: string | null;


### PR DESCRIPTION
## 概要

beta の試合詳細を「プロモート」するための土台として、**掲載大会に紐づく試合詳細を本体ドメインの indexable なネスト URL で公開**し、大会ページ・選手ページと相互リンクさせる。どの掲載大会にも紐づかない野良試合は従来どおり `/beta/matches-results`（noindex）に残す。

設計・決定の経緯は [docs/wiki/score-site-link.md](docs/wiki/score-site-link.md)。

## なぜ

- 現状 `/beta/*` は robots.txt で disallow・sitemap 除外のため、相互リンクを張っても検索流入のタネにならなかった
- 試合詳細を本体の大会・選手ページ（既存のSEO資産）の配下に置き、相互リンクで流入導線を作る
- あわせて、公開 JSON 生成の50件上限による「インデックス済み URL が404になる」リスクを構造的に解消する

## 変更点

**Phase 1 — siteLink 生成・追記型化・移行**
- `lib/siteLink.mjs`: 試合を大会データと突合し `{ tournamentPath, entryNos }` を解決（entryNo が大会エントリーに実在する場合のみ。野良は null）
- `scripts/generate-beta-matches-json.mjs`: **50件上限を撤廃**、出力ディレクトリ全削除をやめ**追記型**に変更、各試合に `siteLink` をベイク。Supabase 無しの再生成でも付与するため `npm run prebuild` で既存試合を移行可能
- `src/types/database.ts`: `MatchSiteLink` / `Match.siteLink`

**Phase 2 — ネストルートと URL 振り分け**
- 新ルート `/tournaments/.../matches/[matchId]`（試合詳細コンポーネントは `/beta/matches-results/[matchId]` と共通）
- `lib/siteConfig.ts` `getPublicMatchDetailPath(match)` を siteLink 有無で分岐
- canonical: ネストページ→自身、`/beta` の同一試合→ネスト（重複回避）、野良→`/beta` のまま

**Phase 3 — 逆引き表と本体ページのリンク**
- `scripts/generate-match-reverse-index.mjs`: 大会別・選手別の逆引き表を生成（ラウンド順 決勝→準決勝→準々決勝→… にソート）
- `lib/matchReverseIndex.ts` で読み出し、大会ページ・選手結果ページに「スコア詳細のある試合」セクションを追加

**Phase 4 — 作成 UI のエントリー選択**
- dev 専用 API `src/pages/api/tournament-entries.ts` + `src/pages/beta/matches/create.tsx` のエントリー選択ドロップダウン。選手情報を大会データから自動入力し siteLink の解決精度を上げる（手入力はフォールバックで残存）

**横断**
- `next-sitemap.config.js` に `additionalPaths` を追加（深いネストの動的 SSG ルートを next-sitemap が自動列挙しないため）→ sitemap にネスト URL が入る
- `package.json` prebuild 連鎖に reverse-index 生成を追加
- wiki 更新（score-site-link.md / index.md / data-import.md / open-questions.md / beta-matches-results.md）

## 検証

- `npm run build`（prebuild 連鎖・ネストルート生成・postbuild sitemap）が exit 0
- 既存15試合中14件が siteLink 成立（1件は entry 番号が空＝正しく野良判定）
- ネストページ14件が生成され、canonical / sitemap に反映されることを確認
- tsc / eslint クリーン

## レビュー時の注意

- **デプロイ前に本番 Supabase で `npm run prebuild` の実行が必要**（本 PR の JSON は snapshot 15件での移行・検証）。上限撤廃により本番DBの全試合が初めて全件出力される
- score モードでは従来どおりフラットな `/matches/[id]` を維持（ネストは softeni-pick mode のみ）
- 作成 UI のエントリー選択 API は dev 専用（静的 export には含まれない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)