### PR TITLE
fix: ProfilePage構造化データのGSCエラーを解消

### DIFF
--- a/docs/wiki/public-pages.md
+++ b/docs/wiki/public-pages.md
@@ -113,7 +113,9 @@
 
 メタ・構造化データ:
 
-- 選手結果ページの JSON-LD は `ProfilePage` + `Person`。`dateCreated` / `dateModified` は実データ（初出/最新出場大会の日付）由来とし、ビルド日は使わない
+- 選手結果ページの JSON-LD は `ProfilePage` + `mainEntity: Person`。`dateCreated` / `dateModified` は実データ（初出/最新出場大会の日付）由来とし、ビルド日は使わない
+  - `dateCreated` / `dateModified` は ISO 8601 の**日時（タイムゾーン付き）**で出力する（例 `2024-07-28T00:00:00+09:00`）。Google ProfilePage は日付のみだと「日時値が無効」と判定するため、データ上の `YYYY-MM-DD` に JST オフセット `T00:00:00+09:00` を付与する（2026-06 修正）
+  - ProfilePage では `mainEntityOfPage` を出力しない（Google が認識せず「項目を認識できません」になる）。エンティティ指定は `mainEntity` を使う（2026-06 修正）
 - 大会結果ページの `datePublished` / `dateModified` も大会開催日由来
 - canonical は必ず実 URL（trailingSlash あり）に一致させる。プロフィールの `/information` canonical は不具合だったため修正済み
 - title / description には所属チーム・直近成績・通算成績を埋め込み、ページごとに一意化する

--- a/src/pages/players/[id]/results.tsx
+++ b/src/pages/players/[id]/results.tsx
@@ -135,13 +135,13 @@ export default function PlayerResultsPage({
             __html: JSON.stringify({
               '@context': 'https://schema.org',
               '@type': 'ProfilePage',
-              ...(firstActivityDate && { dateCreated: firstActivityDate }),
-              ...(latestActivityDate && { dateModified: latestActivityDate }),
+              ...(firstActivityDate && {
+                dateCreated: `${firstActivityDate}T00:00:00+09:00`,
+              }),
+              ...(latestActivityDate && {
+                dateModified: `${latestActivityDate}T00:00:00+09:00`,
+              }),
               inLanguage: 'ja',
-              mainEntityOfPage: {
-                '@type': 'WebPage',
-                '@id': pageUrl,
-              },
               mainEntity: {
                 '@type': 'Person',
                 name: fullName,


### PR DESCRIPTION
## 概要

Google Search Console で報告されていた構造化データの3エラーを修正します。表示は「sitemap」ですが、実体は選手結果ページ `src/pages/players/[id]/results.tsx` の `ProfilePage` JSON-LD が原因でした。

報告されていたメッセージ:
- 「dateCreated」の日時値が無効です
- 「dateModified」の日時値が無効です
- 項目「mainEntityOfPage」を認識できません

`dateCreated` を出力しているのはこのページだけのため、3エラーはすべて ProfilePage に集約されます。

## 原因と修正

[Google ProfilePage 仕様](https://developers.google.com/search/docs/appearance/structured-data/profile-page) に基づく:

1. **日時値が無効** — `dateCreated`/`dateModified` を日付のみ（`2024-07-28`）で出力していた。Google は ISO 8601 の日時（タイムゾーン付き）を要求するため、JST オフセットを付与（`2024-07-28T00:00:00+09:00`）。
2. **mainEntityOfPage 認識不可** — ProfilePage では認識されないプロパティのため削除。エンティティ指定は既存の `mainEntity`（Person）で担保。

データ側の `startDate`/`endDate` は正しい `YYYY-MM-DD` で、問題は出力形式のみ。

## その他のページ

`tournaments/` や `teams/` の `Article` 型ページも `dateModified` を日付のみで出していますが、`Article` 型では日付のみが許容され `mainEntityOfPage` も正規プロパティのため、今回の対象外（修正不要）。

## ドキュメント

`docs/wiki/public-pages.md` の選手ページ SEO 方針に上記仕様を追記。

## 検証

- `tsc --noEmit` で型エラーなし
- マージ後、GSC の「修正を検証」で再クロールをリクエスト予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)