### PR TITLE
wiki/README をSNS 1日目ツールの実装に同期

### DIFF
--- a/docs/wiki/sns-day1-images.md
+++ b/docs/wiki/sns-day1-images.md
@@ -55,7 +55,8 @@
 
 画像は「文字で代替しにくい主役カット」だけにし、サマリ・番狂わせ・結果ダイジェストは
 **投稿本文（caption）＋スレッド返信（thread）のテキスト**で出す。テキストは
-`out/captions/<カテゴリ>.txt`（本文）と `_thread.txt`（返信）に生成する。
+`<--out>/captions/<カテゴリ>.txt`（本文）と `<カテゴリ>_thread.txt`（返信）に生成する
+（例: `--out out/sns` なら `out/sns/captions/`）。
 
 - 氏名は**フルネーム**（姓＋名）。所属は `学校（都道府県）`。
 - 画像サイズはX向けに **16:9(1200×675) / 1:1(1200×1200) / 4:5(1200×1500)** の3種に統一。
@@ -85,14 +86,19 @@
 - 配信URL・コート割・開始時刻詳細は**載せない**（手元に無い／外部依存）。
 - 情報JSONに該当年レコードが無い場合（例: 2026は未登録）は会場を省略して描画する。
 
-## CLI（予定インターフェース）
+## CLI（実装済み）
+
+会場（CTA）の描画には情報JSON参照のため `--tournament` / `--year` が必要。
+個別スクリプトは details.json を位置引数で受ける。
 
 ```bash
 # ダブルス1日目（本選進出）
-python tools/sns-images/day1_doubles.py <details.json> --next-date "6/28(日)9:00〜" --out out/sns
+python tools/sns-images/day1_doubles.py <details.json> \
+    --next-date "6/28(日)9:00〜" --tournament highschool-japan-cup --year 2026 --out out/sns
 
 # シングルス1日目（ベスト4）
-python tools/sns-images/day1_singles.py <details.json> --next-date "6/27(土)9:00〜" --out out/sns
+python tools/sns-images/day1_singles.py <details.json> \
+    --next-date "6/27(土)9:00〜" --tournament highschool-japan-cup --year 2026 --out out/sns
 
 # シングルス完結報告
 python tools/sns-images/result_singles.py <details.json> --out out/sns

--- a/tools/sns-images/README.md
+++ b/tools/sns-images/README.md
@@ -13,12 +13,12 @@ source .venv/bin/activate  # または python3 を直接
 `docs/wiki/sns-day1-images.md`。共通ロジックは `day1lib.py`、キャプションは `captions.py`。
 
 ```bash
-# シングルス1日目（ベスト4確定）: 表紙+CTA / ベスト4 / 準決勝カード / ハイライト
+# シングルス1日目（ベスト4確定）: 表紙+CTA / ベスト4一覧 / 準決勝確定カード（最大3枚）
 python tools/sns-images/day1_singles.py \
     data/tournaments/details/highschool-japan-cup/2026/singles-none-boys.json \
     --next-date "6/27(土)9:00〜" --tournament highschool-japan-cup --year 2026 --out out/sns
 
-# ダブルス1日目（予選リーグ終了）: 表紙+CTA / 進出サマリ / 進出ペア一覧 / 前年実績
+# ダブルス1日目（予選リーグ終了）: 表紙+CTA / 本選進出ペア一覧（1〜2枚）
 python tools/sns-images/day1_doubles.py \
     data/tournaments/details/highschool-japan-cup/2026/doubles-none-boys.json \
     --next-date "6/28(日)9:00〜" --tournament highschool-japan-cup --year 2026 --out out/sns


### PR DESCRIPTION
## 概要

LLM wiki の点検で見つかった、SNS 1日目投稿素材ツール（`tools/sns-images/`）に関するドキュメントと実装の同期ずれを修正します。AGENTS.md のルール（実装が source of truth）に沿った doc-sync のみで、コード挙動の変更はありません。

## 変更内容

- **README**: 実スクリプトが生成しない画像（シングルスの「ハイライト」、ダブルスの「進出サマリ」「前年実績」）の記載を実際の出力に訂正
  - シングルス → 表紙+CTA / ベスト4一覧 / 準決勝確定カード（最大3枚）
  - ダブルス → 表紙+CTA / 本選進出ペア一覧（1〜2枚）
- **wiki CLI 節**: 「予定インターフェース」→「実装済み」に更新し、CTA の会場描画に必要な `--tournament` / `--year` を例に追記
- **caption 出力パス**: `out/captions/` → `<--out>/captions/`（例つき）に訂正

これで wiki・README・実装の3者が一致します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)