### PR TITLE
大会ハブページを追加し歴代結果への内部リンク・SEOを強化

### DIFF
--- a/docs/wiki/public-pages.md
+++ b/docs/wiki/public-pages.md
@@ -83,6 +83,17 @@
 - 結果未反映で外部リンク導線のみの大会は `外部掲載` を表示する
 - 一覧構造や既存URLは変更しない
 
+大会ハブページ（`/tournaments/[generation]/[tournamentId]`、2026-06 追加）:
+
+- 年度を含まない「ソフトテニス 大会名 結果」検索クエリの受け皿となる、1大会の歴代結果まとめページ
+- `getStaticPaths` は `data/tournaments/details/{tournamentId}` 配下の年度ディレクトリを走査して生成し、`generation` は `index.json` / `local_index.json` の `generationId` から解決する（不明時は `unknown`）
+- 実際に詳細データがある年度・種別のみをチップでリンク化し、年度降順で表示する。種別ラベルは `information/{tournamentId}.json` の `categories[].label` から解決する
+- 各詳細 JSON から優勝ペア（`results[].tournament.rank.kind === 'winner'` のエントリーの選手名・所属）を抽出し、「歴代優勝者」表を表示する
+- 構造化データは `CollectionPage` / `ItemList`（歴代優勝者）/ `BreadcrumbList` を出力する
+- 大会一覧カード（`TournamentCard`）と年度別結果ページのパンくずからハブページへ内部リンクする
+- 年度別結果ページ（`/tournaments/.../[gender]`）には `SportsEvent` 構造化データと冒頭の説明文を追加し、title / description を「結果・トーナメント表」を含む形に改善する
+- 実装: `src/pages/tournaments/[generation]/[tournamentId]/index.tsx`、`src/components/tournaments/TournamentCard.tsx`
+
 `score` mode:
 
 - `/matches`

--- a/src/components/tournaments/TournamentCard.tsx
+++ b/src/components/tournaments/TournamentCard.tsx
@@ -29,11 +29,23 @@ type Props = {
 export const TournamentCard = ({ tournament }: Props) => {
   const { id, name, generation, groups } = tournament;
 
+  const hubHref = `/tournaments/${generation}/${id}`;
+
   return (
     <div className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow">
-      <h3 className="text-lg font-semibold mb-4 border-b text-gray-800 dark:text-white">
-        {name}
-      </h3>
+      <div className="mb-4 border-b pb-2 flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+        <h3 className="text-lg font-semibold text-gray-800 dark:text-white">
+          <Link href={hubHref} className="hover:underline">
+            {name}
+          </Link>
+        </h3>
+        <Link
+          href={hubHref}
+          className="text-sm text-blue-600 dark:text-blue-400 hover:underline whitespace-nowrap"
+        >
+          歴代結果・優勝者まとめ →
+        </Link>
+      </div>
 
       {/* 年ごとにカテゴリチップを並べる */}
       {groups

--- a/src/pages/tournaments/[generation]/[tournamentId]/[year]/[gameCategory]/[ageCategory]/[gender]/index.tsx
+++ b/src/pages/tournaments/[generation]/[tournamentId]/[year]/[gameCategory]/[ageCategory]/[gender]/index.tsx
@@ -105,6 +105,13 @@ export default function TournamentYearResultPage({
     });
   }
 
+  if (label) {
+    breadcrumbs.push({
+      label: `${label} 結果`,
+      href: `/tournaments/${generation}/${tournamentId}`,
+    });
+  }
+
   breadcrumbs.push({
     label: `${label} ${year}年度 ${categoryLabel ? `${categoryLabel}` : ''}`,
     href: `/tournaments/${generation}/${tournamentId}/${year}/${gameCategory}/${ageCategory}/${gender}`,
@@ -113,8 +120,8 @@ export default function TournamentYearResultPage({
   return (
     <>
       <MetaHead
-        title={`${label} ${year}年 ${categoryLabel} | ソフトテニス情報`}
-        description={`${label} ${year}年 ${categoryLabel}の試合結果・トーナメント表・成績一覧`}
+        title={`${label} ${year}年${categoryLabel ? ` ${categoryLabel}` : ''} 結果・トーナメント表 | ソフトテニス情報`}
+        description={`ソフトテニス「${label}」${year}年${categoryLabel ? ` ${categoryLabel}` : ''}の試合結果・トーナメント表・優勝/上位入賞者の成績一覧。${infoForYear?.location ? `開催地は${infoForYear.location}。` : ''}過去大会の結果もまとめて掲載しています。`}
         url={pageUrl}
         type="article"
       />
@@ -137,7 +144,32 @@ export default function TournamentYearResultPage({
               }),
               inLanguage: 'ja',
               mainEntityOfPage: { '@type': 'WebPage', '@id': pageUrl },
-              description: `${label} ${year}年度  ${categoryLabel ? `${categoryLabel} ` : ''}のソフトテニス大会結果を確認できます。過去の大会結果も掲載`,
+              description: `ソフトテニス「${label}」${year}年度${categoryLabel ? ` ${categoryLabel}` : ''}の試合結果・トーナメント表・優勝/上位入賞者の成績一覧。過去大会の結果もまとめて掲載しています。`,
+            }),
+          }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'SportsEvent',
+              name: `${label} ${year}年${categoryLabel ? ` ${categoryLabel}` : ''} 結果`,
+              sport: 'ソフトテニス',
+              inLanguage: 'ja',
+              url: pageUrl,
+              ...(infoForYear?.startDate && {
+                startDate: infoForYear.startDate,
+              }),
+              ...(infoForYear?.endDate && { endDate: infoForYear.endDate }),
+              ...(infoForYear?.location && {
+                location: {
+                  '@type': 'Place',
+                  name: infoForYear.location,
+                },
+              }),
+              organizer: { '@type': 'Organization', name: 'Softeni Pick' },
+              description: `ソフトテニス「${label}」${year}年${categoryLabel ? ` ${categoryLabel}` : ''}の試合結果・トーナメント表・成績一覧。`,
             }),
           }}
         />
@@ -172,6 +204,11 @@ export default function TournamentYearResultPage({
           大会結果
         </h1>
         <section className="mb-6 px-1">
+          <p className="mb-2 text-sm text-gray-700 dark:text-gray-200">
+            ソフトテニス「{label}」{year}年度
+            {categoryLabel ? `${categoryLabel} ` : ''}
+            の試合結果・トーナメント表・優勝/上位入賞者の成績一覧です。
+          </p>
           {infoForYear?.location &&
             infoForYear?.startDate &&
             infoForYear?.endDate && (

--- a/src/pages/tournaments/[generation]/[tournamentId]/index.tsx
+++ b/src/pages/tournaments/[generation]/[tournamentId]/index.tsx
@@ -1,0 +1,498 @@
+// pages/tournaments/[generation]/[tournamentId]/index.tsx
+// 大会ハブページ: 1大会の歴代（年度別・種別別）結果をまとめて内部リンクする。
+// 「ソフトテニス 大会名 結果」など年度を含まない検索クエリの受け皿。
+
+import fs from 'fs';
+import path from 'path';
+
+import type { GetStaticPaths, GetStaticProps } from 'next';
+import Head from 'next/head';
+import Link from 'next/link';
+
+import Breadcrumbs from '@/components/Breadcrumb';
+import MetaHead from '@/components/MetaHead';
+import PageLayout from '@/components/PageLayout';
+import {
+  TournamentIndexEntry,
+  TournamentInformationEntry,
+} from '@/types/index';
+
+type CategoryLink = {
+  label: string;
+  category: string;
+  age: string;
+  gender: string;
+  href: string;
+  winner: string | null;
+};
+
+type YearGroup = {
+  year: string;
+  location: string | null;
+  startDate: string | null;
+  endDate: string | null;
+  categories: CategoryLink[];
+};
+
+interface TournamentHubPageProps {
+  generation: string;
+  tournamentId: string;
+  label: string;
+  officialUrl: string | null;
+  yearGroups: YearGroup[];
+}
+
+export default function TournamentHubPage({
+  generation,
+  tournamentId,
+  label,
+  officialUrl,
+  yearGroups,
+}: TournamentHubPageProps) {
+  const pageUrl = `https://softeni-pick.com/tournaments/${generation}/${tournamentId}/`;
+
+  const years = yearGroups.map((g) => g.year);
+  const latestYear = years[0] ?? '';
+  const oldestYear = years[years.length - 1] ?? '';
+  const yearRange =
+    latestYear && oldestYear && latestYear !== oldestYear
+      ? `${oldestYear}〜${latestYear}年`
+      : latestYear
+        ? `${latestYear}年`
+        : '';
+
+  const championRows = yearGroups.flatMap((g) =>
+    g.categories
+      .filter((c) => c.winner)
+      .map((c) => ({
+        year: g.year,
+        categoryLabel: c.label,
+        winner: c.winner as string,
+        href: c.href,
+        location: g.location,
+        startDate: g.startDate,
+        endDate: g.endDate,
+      })),
+  );
+
+  const breadcrumbs = [
+    { label: 'ホーム', href: '/' },
+    { label: '大会結果一覧', href: '/tournaments' },
+    {
+      label: `${label} 結果`,
+      href: `/tournaments/${generation}/${tournamentId}`,
+    },
+  ];
+
+  const title = `${label} 結果・歴代優勝/上位入賞者まとめ | ソフトテニス情報`;
+  const description = `ソフトテニス「${label}」の歴代大会結果・トーナメント表・優勝/上位入賞者を年度別にまとめています。${yearRange ? `${yearRange}の` : ''}試合結果を一覧から確認できます。`;
+
+  return (
+    <>
+      <MetaHead
+        title={title}
+        description={description}
+        url={pageUrl}
+        type="website"
+      />
+
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'CollectionPage',
+              name: `${label} 結果（歴代一覧）`,
+              inLanguage: 'ja',
+              url: pageUrl,
+              about: {
+                '@type': 'Thing',
+                name: `ソフトテニス ${label}`,
+              },
+              description,
+            }),
+          }}
+        />
+        {championRows.length > 0 && (
+          <script
+            type="application/ld+json"
+            dangerouslySetInnerHTML={{
+              __html: JSON.stringify({
+                '@context': 'https://schema.org',
+                '@type': 'ItemList',
+                name: `${label} 歴代優勝者`,
+                numberOfItems: championRows.length,
+                itemListElement: championRows.map((r, index) => ({
+                  '@type': 'ListItem',
+                  position: index + 1,
+                  item: {
+                    '@type': 'SportsEvent',
+                    name: `${label} ${r.year}年 ${r.categoryLabel}`,
+                    sport: 'ソフトテニス',
+                    inLanguage: 'ja',
+                    url: `https://softeni-pick.com${r.href}`,
+                    ...(r.startDate && { startDate: r.startDate }),
+                    ...(r.endDate && { endDate: r.endDate }),
+                    ...(r.location && {
+                      location: { '@type': 'Place', name: r.location },
+                    }),
+                    description: `優勝: ${r.winner}`,
+                  },
+                })),
+              }),
+            }}
+          />
+        )}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@type': 'BreadcrumbList',
+              itemListElement: breadcrumbs.map((crumb, index) => ({
+                '@type': 'ListItem',
+                position: index + 1,
+                name: crumb.label,
+                item: `https://softeni-pick.com${crumb.href}`,
+              })),
+            }),
+          }}
+        />
+      </Head>
+
+      <PageLayout>
+        <Breadcrumbs crumbs={breadcrumbs} />
+
+        <h1 className="text-2xl font-bold mb-4">
+          {label} 大会結果（歴代一覧）
+        </h1>
+
+        <section className="mb-6 px-1">
+          <p className="mb-2 text-sm text-gray-700 dark:text-gray-200">
+            ソフトテニス「{label}
+            」の歴代の試合結果・トーナメント表・優勝/上位入賞者を年度別にまとめています。
+            {yearRange ? `${yearRange}の大会結果を掲載中です。` : ''}
+            見たい年度・種別を選ぶと、各大会の詳細な結果ページに移動できます。
+          </p>
+          {officialUrl && (
+            <p className="text-sm text-gray-600 dark:text-gray-300">
+              公式サイト:{' '}
+              <a
+                href={officialUrl}
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {officialUrl}
+              </a>
+            </p>
+          )}
+        </section>
+
+        {championRows.length > 0 && (
+          <section className="mb-10">
+            <h2 className="text-lg font-bold mb-3">{label} 歴代優勝者</h2>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm border-collapse">
+                <thead>
+                  <tr className="border-b border-gray-300 dark:border-gray-600 text-left">
+                    <th className="py-2 pr-3 font-semibold whitespace-nowrap">
+                      年度
+                    </th>
+                    <th className="py-2 pr-3 font-semibold whitespace-nowrap">
+                      種別
+                    </th>
+                    <th className="py-2 pr-3 font-semibold">優勝</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {championRows.map((r) => (
+                    <tr
+                      key={`${r.year}-${r.categoryLabel}`}
+                      className="border-b border-gray-100 dark:border-gray-800"
+                    >
+                      <td className="py-2 pr-3 align-top whitespace-nowrap">
+                        <Link
+                          href={r.href}
+                          className="text-blue-600 dark:text-blue-400 hover:underline"
+                        >
+                          {r.year}年度
+                        </Link>
+                      </td>
+                      <td className="py-2 pr-3 align-top">{r.categoryLabel}</td>
+                      <td className="py-2 pr-3 align-top">{r.winner}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {yearGroups.length === 0 ? (
+          <p className="text-sm text-gray-500">
+            現在、掲載中の結果データがありません。
+          </p>
+        ) : (
+          yearGroups.map((g) => (
+            <section className="mb-8" key={g.year}>
+              <h2 className="text-lg font-bold mb-1">
+                {label} {g.year}年度 結果
+              </h2>
+              {(g.location || g.startDate) && (
+                <p className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+                  {g.location ? `開催地:${g.location}` : ''}
+                  {g.location && g.startDate ? ' / ' : ''}
+                  {g.startDate
+                    ? `日程:${g.startDate}${g.endDate ? `〜${g.endDate}` : ''}`
+                    : ''}
+                </p>
+              )}
+              <ul className="flex flex-wrap gap-2">
+                {g.categories.map((c) => (
+                  <li key={`${g.year}-${c.category}-${c.age}-${c.gender}`}>
+                    <Link href={c.href}>
+                      <span className="inline-block bg-blue-100 text-blue-800 px-3 py-1 rounded-full text-sm hover:opacity-80 transition dark:bg-blue-900 dark:text-blue-100">
+                        {c.label}
+                      </span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))
+        )}
+
+        <div className="text-right mt-10 mb-2">
+          <Link
+            href="/tournaments"
+            className="text-sm text-blue-500 hover:underline"
+          >
+            大会結果一覧へ
+          </Link>
+        </div>
+      </PageLayout>
+    </>
+  );
+}
+
+const DETAILS_ROOT = ['data', 'tournaments', 'details'];
+
+// 詳細JSONから優勝ペア（選手名・所属）を抽出する。なければ null。
+function extractWinner(detailPath: string): string | null {
+  try {
+    const data = JSON.parse(fs.readFileSync(detailPath, 'utf-8')) as {
+      participants?: Array<{
+        id: string;
+        lastName?: string;
+        firstName?: string;
+        team?: string;
+      }>;
+      entries?: Array<{ entryNo: number; playerIds: string[] }>;
+      results?: Array<{
+        entryNo: number;
+        tournament?: { rank?: { kind?: string } };
+      }>;
+    };
+    const winResult = (data.results ?? []).find(
+      (r) => r.tournament?.rank?.kind === 'winner',
+    );
+    if (!winResult) return null;
+    const entry = (data.entries ?? []).find(
+      (e) => e.entryNo === winResult.entryNo,
+    );
+    if (!entry) return null;
+    const pmap = new Map(
+      (data.participants ?? []).map((p) => [p.id, p] as const),
+    );
+    const names = entry.playerIds.map((id) => {
+      const p = pmap.get(id);
+      return p ? `${p.lastName ?? ''}${p.firstName ?? ''}` : id;
+    });
+    const teams = [
+      ...new Set(
+        entry.playerIds
+          .map((id) => pmap.get(id)?.team)
+          .filter((t): t is string => Boolean(t)),
+      ),
+    ];
+    const nameStr = names.join('・');
+    return teams.length > 0 ? `${nameStr}（${teams.join('・')}）` : nameStr;
+  } catch {
+    return null;
+  }
+}
+
+function loadGenerationMap(): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const file of ['index.json', 'local_index.json']) {
+    const p = path.join(process.cwd(), 'data', 'tournaments', file);
+    if (!fs.existsSync(p)) continue;
+    try {
+      const idx = JSON.parse(fs.readFileSync(p, 'utf-8'));
+      if (Array.isArray(idx)) {
+        for (const it of idx) {
+          if (it && typeof it === 'object') {
+            const entry = it as Record<string, unknown>;
+            const tid = entry['tournamentId'];
+            const gen = entry['generationId'];
+            if (typeof tid === 'string') {
+              map[tid] = typeof gen === 'string' ? gen : 'unknown';
+            }
+          }
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return map;
+}
+
+function loadIndexEntry(tournamentId: string): TournamentIndexEntry | null {
+  for (const file of ['index.json', 'local_index.json']) {
+    const p = path.join(process.cwd(), 'data', 'tournaments', file);
+    if (!fs.existsSync(p)) continue;
+    try {
+      const idx = JSON.parse(fs.readFileSync(p, 'utf-8'));
+      if (Array.isArray(idx)) {
+        const found = idx.find(
+          (it) =>
+            it &&
+            typeof it === 'object' &&
+            (it as TournamentIndexEntry).tournamentId === tournamentId,
+        );
+        if (found) return found as TournamentIndexEntry;
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return null;
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const detailsRoot = path.join(process.cwd(), ...DETAILS_ROOT);
+  if (!fs.existsSync(detailsRoot)) {
+    return { paths: [], fallback: false };
+  }
+
+  const generationMap = loadGenerationMap();
+  const tournamentIds = fs.readdirSync(detailsRoot).filter((n) => {
+    const p = path.join(detailsRoot, n);
+    return fs.statSync(p).isDirectory();
+  });
+
+  const paths = tournamentIds.map((tid) => ({
+    params: {
+      generation: generationMap[tid] ?? 'unknown',
+      tournamentId: tid,
+    },
+  }));
+
+  return { paths, fallback: false };
+};
+
+export const getStaticProps: GetStaticProps = async (context) => {
+  const { generation, tournamentId } = context.params as {
+    generation: string;
+    tournamentId: string;
+  };
+
+  const indexEntry = loadIndexEntry(tournamentId);
+  const label = indexEntry?.label ?? tournamentId;
+  const officialUrl = indexEntry?.officialUrl || null;
+
+  // information から年度ごとの開催情報・カテゴリラベルを取得
+  const infoPath = path.join(
+    process.cwd(),
+    'data',
+    'tournaments',
+    'information',
+    `${tournamentId}.json`,
+  );
+  let information: TournamentInformationEntry[] = [];
+  if (fs.existsSync(infoPath)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(infoPath, 'utf-8'));
+      if (Array.isArray(parsed)) information = parsed;
+    } catch {
+      // ignore
+    }
+  }
+
+  const categoryLabelByYear = new Map<string, Map<string, string>>();
+  const infoByYear = new Map<string, TournamentInformationEntry>();
+  for (const entry of information) {
+    const y = String(entry.year);
+    infoByYear.set(y, entry);
+    const m = new Map<string, string>();
+    for (const cat of entry.categories ?? []) {
+      m.set(cat.categoryId, cat.label);
+    }
+    categoryLabelByYear.set(y, m);
+  }
+
+  // details ディレクトリを走査し、実際にデータがある年度・種別のみリンク化
+  const tidDir = path.join(process.cwd(), ...DETAILS_ROOT, tournamentId);
+  const yearGroups: YearGroup[] = [];
+
+  if (fs.existsSync(tidDir)) {
+    const years = fs
+      .readdirSync(tidDir)
+      .filter((y) => {
+        const p = path.join(tidDir, y);
+        return fs.statSync(p).isDirectory();
+      })
+      .sort((a, b) => Number(b) - Number(a)); // 年度降順
+
+    for (const y of years) {
+      const yearDir = path.join(tidDir, y);
+      const files = fs.readdirSync(yearDir).filter((f) => f.endsWith('.json'));
+
+      const labelMap = categoryLabelByYear.get(y) ?? new Map<string, string>();
+      const categories: CategoryLink[] = [];
+
+      for (const f of files) {
+        const base = f.replace(/\.json$/, '');
+        const parts = base.split('-');
+        if (parts.length < 3) continue;
+        const gender = parts.pop() as string;
+        const age = parts.pop() as string;
+        const category = parts.join('-');
+        const categoryId = `${category}-${age}-${gender}`;
+
+        categories.push({
+          label: labelMap.get(categoryId) ?? categoryId,
+          category,
+          age,
+          gender,
+          href: `/tournaments/${generation}/${tournamentId}/${y}/${category}/${age}/${gender}`,
+          winner: extractWinner(path.join(yearDir, f)),
+        });
+      }
+
+      if (categories.length === 0) continue;
+
+      const info = infoByYear.get(y) ?? null;
+      yearGroups.push({
+        year: y,
+        location: info?.location || null,
+        startDate: info?.startDate || null,
+        endDate: info?.endDate || null,
+        categories,
+      });
+    }
+  }
+
+  return {
+    props: {
+      generation,
+      tournamentId,
+      label,
+      officialUrl,
+      yearGroups,
+    },
+  };
+};


### PR DESCRIPTION
## 概要

各大会の「年度を含まない」検索クエリ（例: `ソフトテニス 大会名 結果`）の受け皿となる**大会ハブページ**を追加し、歴代結果への内部リンクと構造化データを強化しました。

## 変更内容

### 新規: 大会ハブページ `/[generation]/[tournamentId]`
- `data/tournaments/details` を走査し、実データがある年度・種別のみをリンク化
- 詳細JSONから優勝ペアを抽出し「歴代優勝者」一覧を表示
- `CollectionPage` / `ItemList`(歴代優勝者) / `BreadcrumbList` の JSON-LD を出力
- 公式サイトリンク、年度範囲の説明文を表示

### `TournamentCard`
- 大会名と「歴代結果・優勝者まとめ →」リンクからハブページへ導線を追加

### 年度別結果ページ
- ハブページへのパンくずを追加
- `SportsEvent` 構造化データ・説明文を追加し、title/description を改善

## 確認

- `tsc --noEmit` ✅
- `eslint`（変更ファイル）✅
- 優勝者抽出ロジックを実データ構造（`results[].tournament.rank.kind === 'winner'`）で確認 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)