### PR TITLE
fix: milestoneKindTag の種別タグにダークモード変種を追加

### DIFF
--- a/src/components/milestoneKindTag.ts
+++ b/src/components/milestoneKindTag.ts
@@ -8,18 +8,24 @@
 export type MilestoneKindTagInfo = {
   /** バッジに添える短い種別テキスト（例: 「連覇」） */
   text: string;
-  /** 種別タグの配色（Tailwind の背景/文字色クラス） */
+  /**
+   * 種別タグの配色（Tailwind の背景/文字色クラス）。
+   * 種別ごとに異なる色相で一目の区別を付ける用途のため、セマンティックな
+   * デザイントークン（globals.css・§2.1）には該当色が無く、生パレットを使う。
+   * ダーク時は背景を一段深く（`700`）してバッジ本体（dark:bg-*-900）の上で
+   * 落ち着かせつつ、白文字とのコントラストを保つ。
+   */
   className: string;
 };
 
 const KIND_TAG: Record<string, MilestoneKindTagInfo> = {
-  'repeat-title': { text: '連覇', className: 'bg-amber-600 text-white' },
-  'first-title': { text: '初優勝', className: 'bg-emerald-600 text-white' },
-  'nth-title': { text: '優勝', className: 'bg-sky-600 text-white' },
-  'champion-defeat': { text: '王者撃破', className: 'bg-rose-600 text-white' },
-  'career-wins': { text: '節目', className: 'bg-violet-600 text-white' },
-  'best4-first': { text: 'ベスト4初', className: 'bg-teal-600 text-white' },
-  'first-appearance': { text: '初出場', className: 'bg-gray-600 text-white' },
+  'repeat-title': { text: '連覇', className: 'bg-amber-600 text-white dark:bg-amber-700' },
+  'first-title': { text: '初優勝', className: 'bg-emerald-600 text-white dark:bg-emerald-700' },
+  'nth-title': { text: '優勝', className: 'bg-sky-600 text-white dark:bg-sky-700' },
+  'champion-defeat': { text: '王者撃破', className: 'bg-rose-600 text-white dark:bg-rose-700' },
+  'career-wins': { text: '節目', className: 'bg-violet-600 text-white dark:bg-violet-700' },
+  'best4-first': { text: 'ベスト4初', className: 'bg-teal-600 text-white dark:bg-teal-700' },
+  'first-appearance': { text: '初出場', className: 'bg-gray-600 text-white dark:bg-gray-700' },
 };
 
 /** kind に対応する種別タグ情報を返す。未知の kind は null（タグなしでラベルのみ表示）。 */


### PR DESCRIPTION
## 概要

`milestoneKindTag.ts` の種別タグ配色が生パレットの `*-600` のみで `dark:` 変種を持たず、テーマ(ダークモード)に追従していなかった。7種すべてに `dark:bg-*-700` を付与して修正する。

- ダーク時は背景を一段深く(`700`)し、バッジ本体(`dark:bg-*-900`)の上で落ち着かせつつ白文字とのコントラストを保つ。
- テキスト(`text-white`)はライト/ダーク両モードで維持。

## 実施タスクの前提訂正(実装が正)

指示の前提と実コードに食い違いがあったため、実態に合わせて実施した:

- **`D-023` は存在しない。** トークン決定は D-022。`globals.css` のトークンは10個のセマンティックトークンのみで、`warning`/`success` トークンや7色分のカテゴリ配色は存在しない。
- **`MilestoneBadge.tsx` もトークン未移行。** 本体は生パレット(`bg-amber-100 … dark:bg-amber-900`)。「本体はトークン移行済み」という前提は当たらない。
- 本質的な問題(kindタグに `dark:` が無くテーマ追従しない)は事実で、それを修正した。

## 残る割り切り

P4(トークンのみ使用)には未達。7種を一目で区別するにはカテゴリ配色が必要だが、トークン体系にそれが無いため生パレットを継続する。恒久対応が必要になれば「カテゴリトークン新設(D-023 起票 + §2.1 更新)」が筋。

🤖 Generated with [Claude Code](https://claude.com/claude-code)